### PR TITLE
⚡ Bolt: Prevent CPU starvation during telemetry task overruns

### DIFF
--- a/telemetry.cpp
+++ b/telemetry.cpp
@@ -177,6 +177,8 @@ static void telemetryTask(void* pvParameters) {
       // wait for next collection interval
       uint32_t elapsedTime = millis() - startTime;
       if (elapsedTime < sampleInterval) vTaskDelay(pdMS_TO_TICKS(sampleInterval - elapsedTime));
+      // Bolt: Add a minimum safety yield to prevent CPU hogging when the task execution exceeds the interval
+      else vTaskDelay(1);
     }
     
     // capture finished, write remaining buff to storage 


### PR DESCRIPTION
💡 What: Added an `else vTaskDelay(1);` branch to the periodic data collection loop in `telemetry.cpp` when `elapsedTime >= sampleInterval`.

🎯 Why: In FreeRTOS, if a task runs in a tight `while` loop without yielding (which happens here if `elapsedTime >= sampleInterval`), it can hog the CPU, starve lower-priority tasks, and potentially trigger the Task Watchdog Timer (TWDT). Adding a 1-tick delay ensures the scheduler gets a chance to breathe and let other tasks execute, making the system much more robust and preventing CPU starvation under high load.

📊 Impact: Prevents potential CPU starvation and watch-dog panics during system high-load when the collection interval is breached, making the entire device more responsive and efficient.

🧪 Measurement: Verify by artificially simulating a slow task inside the `while(teleUse)` loop (e.g., adding `delay(sampleInterval + 10)`) and observing that the system watchdog is not triggered, and other HTTP server/system tasks remain responsive. Verified locally passing `cppcheck --enable=performance .`.

---
*PR created automatically by Jules for task [15295287993408618035](https://jules.google.com/task/15295287993408618035) started by @ManupaKDU*