### PR TITLE
🎨 Palette: Fix input label associations for improved accessibility

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1220,7 +1220,7 @@
                     </div>
                   </div>
                   <div class="input-group" id="motion-group">
-                    <label for="motion">Motion Sensitivity</label>
+                    <label for="motionVal">Motion Sensitivity</label>
                     <input title="Set motion detection sensitivity" type="range" id="motionVal" min="1" max="10" value="7">
                   </div>
                   <div class="input-group" id="minf-group">
@@ -1516,11 +1516,11 @@
                 </svg>
               </div>
               <div class="RCcontrolFmt RCsteerFmt">
-                <input title="Control RC steering" type="range" id="steerDirection" class="RCcontrol immed bigThumb ignore" value=0>
+                <input title="Control RC steering" type="range" id="steerDirection" aria-label="Steer Direction" class="RCcontrol immed bigThumb ignore" value=0>
                 <div name="rangeVal" style="top: 2px" class="rvThumb">0</div>
               </div>
               <div class="RCcontrolFmt RCmotorFmt">
-                <input title="Control RC speed" type="range" id="motorSpeed" class="RCcontrol immed bigThumb ignore" value=0>
+                <input title="Control RC speed" type="range" id="motorSpeed" aria-label="Motor Speed" class="RCcontrol immed bigThumb ignore" value=0>
                 <div name="rangeVal" class="rvThumb">0</div>
               </div>
             </div>


### PR DESCRIPTION
💡 What:
- Fixed a broken `<label>` association for "Motion Sensitivity" by pointing it to the correct `id="motionVal"` instead of `motion`.
- Added missing `aria-label` attributes to the "Steer Direction" and "Motor Speed" `<input type="range">` elements used for RC controls.

🎯 Why:
- Screen readers could not announce the purpose of the RC range inputs because they lacked accessible names.
- Clicking the "Motion Sensitivity" text did not correctly focus the range slider because the `for` attribute did not match the input's `id`.

📸 Before/After:
(Changes are semantic HTML attributes, visual styling is unchanged. Verified with Playwright screenshots).

♿ Accessibility:
- Improves screen reader announcement for RC controls.
- Improves clickable hit area for mouse users on the Motion Sensitivity label.

---
*PR created automatically by Jules for task [2288479275051330646](https://jules.google.com/task/2288479275051330646) started by @ManupaKDU*