### PR TITLE
🎨 Palette: Improve accessibility in Auxil.htm

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-20 - Global Focus Visible Styles for Interactive Elements
 **Learning:** Default browser outlines for interactive elements are often removed globally (`outline: 0;`). When explicit `:focus-visible` styles are implemented, they should cover all keyboard-navigable interactive elements, not just standard `<button>` tags. This includes custom elements like `div[role="button"]`, as well as standard form inputs (`input`, `select`, `textarea`).
 **Action:** When adding `:focus-visible` styles to improve keyboard accessibility, use a broad selector (e.g., `button:focus-visible, [role="button"]:focus-visible, input:focus-visible, select:focus-visible`) to ensure all interactive elements receive a clear, consistent focus ring.
+
+## 2024-05-20 - Custom Checkbox/Toggle Accessibility
+**Learning:** Hiding native checkboxes using `display: none;` removes them from the accessibility tree, breaking keyboard navigation entirely for custom toggle switches.
+**Action:** When styling custom toggle switches, always hide the native `<input type="checkbox">` using `opacity: 0; position: absolute;` instead of `display: none;`. Ensure a sibling element (like a `.slider`) has a `:focus-visible` CSS rule applied when the hidden checkbox is focused, providing vital visual feedback to keyboard users.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -455,7 +455,13 @@
 
       /* Hide the default checkbox */
       .switch input[type="checkbox"] {
-        display: none;
+        opacity: 0;
+        position: absolute;
+      }
+
+      .switch input[type="checkbox"]:focus-visible + .slider {
+        outline: 2px solid var(--buttonActive);
+        outline-offset: 2px;
       }
 
       /* static part */
@@ -812,7 +818,7 @@
           <div id="sidebar">
             <div id="menu-container" class="menu-pinned">
               <nav id="menu-selector" class="menu-pinned menu-closed">
-                <nav class="quick-nav" id="accSettings" name="access-settings">🔧</nav>
+                <nav class="quick-nav" id="accSettings" name="access-settings" title="Access Settings" aria-label="Access Settings" role="button" tabindex="0">🔧</nav>
               </nav>
               <nav class="menu panel" id="access-settings">
                 <input type="checkbox" id="other-cb" class="menu-action">


### PR DESCRIPTION
💡 What: Improved keyboard accessibility for the 'Access Settings' icon and toggle switches in `data/Auxil.htm`.
🎯 Why: The 'Access Settings' icon was missing standard ARIA properties, preventing keyboard focus and trigger actions. The custom toggle switches were entirely removed from the accessibility tree by `display: none;`, preventing keyboard navigation and screen-reader focus. 
📸 Before/After: Checked via playwright.
♿ Accessibility: Replaced `display: none;` on the native checkbox with `opacity: 0; position: absolute;` while adding `:focus-visible` styles to the custom sliders to re-enable keyboard interaction. Additionally, added `role="button"`, `tabindex="0"`, `title`, and `aria-label` to the settings `<nav>` element.

---
*PR created automatically by Jules for task [14121773240311030956](https://jules.google.com/task/14121773240311030956) started by @ManupaKDU*