### PR TITLE
🎨 Palette: Mask password fields in UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -27,3 +27,6 @@
 ## 2024-05-20 - Use Valid HTML Attributes for Input Limitations
 **Learning:** Native HTML `<input>` fields use `maxlength`, not `length`, to enforce character limits on the client side. Using `length=` is an invalid HTML attribute and is silently ignored by the browser, meaning users can type beyond the intended character limit (e.g., for SSIDs or Hostnames) which might cause unexpected truncation or buffer overflows on the backend.
 **Action:** Always use `maxlength="[number]"` and `minlength="[number]"` for text-based `<input>` fields.
+## 2024-04-08 - [Hide Password Inputs]
+**Learning:** Found that multiple sensitive configuration fields (WiFi, FTP, SMTP, and Web passwords) in `Auxil.htm` and `MJPEG2SD.htm` were using the default `text` type, leaving them visible on screen and potentially vulnerable to shoulder-surfing.
+**Action:** Always verify that newly added or existing sensitive input fields explicitly use `type="password"`.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -845,7 +845,7 @@
                   </div>
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_Pass">Password</label>
-                    <input id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password">
+                    <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password">
                   </div>
                   <div class="input-group">
                       <label for="extIP">External&nbsp;IP</label>
@@ -885,7 +885,7 @@
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="FS_Pass">FS password</label>
-                    <input id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password">
+                    <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsWd">FS root dir</label>
@@ -914,7 +914,7 @@
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="SMTP_Pass">SMTP password</label>
-                    <input id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password">
+                    <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="smtp_email">SMTP email</label>
@@ -928,7 +928,7 @@
                   </div>
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Pass">Web password</label>
-                      <input id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password">
+                      <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password">
                   </div>
                   <div class="input-group" id="auth-group">
                     <label for="useHttps">Use HTTPS</label>

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1335,7 +1335,7 @@
                   </div>
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_Pass">Password</label>
-                    <input id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password">
+                    <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password">
                   </div>
                   <div class="input-group">
                       <label for="extIP">External&nbsp;IP</label>
@@ -1375,7 +1375,7 @@
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="FS_Pass">FS password</label>
-                    <input id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password">
+                    <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsWd">FS root dir</label>
@@ -1404,7 +1404,7 @@
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="SMTP_Pass">SMTP password</label>
-                    <input id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password">
+                    <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="smtp_email">SMTP email</label>
@@ -1418,7 +1418,7 @@
                   </div>
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Pass">Web password</label>
-                      <input id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password">
+                      <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password">
                   </div>
                   <div class="input-group" id="auth-group">
                     <label for="useHttps">Use HTTPS</label>


### PR DESCRIPTION
💡 What: Changed the input type of sensitive configuration fields (Router, FS, SMTP, and Web passwords) from the default `text` to `password` in `MJPEG2SD.htm` and `Auxil.htm`.
🎯 Why: Prevents sensitive passwords from being visible on screen during configuration, protecting against shoulder-surfing and aligning with standard UX practices.
📸 Before/After: Visual change only in browser masking.
♿ Accessibility: No significant accessibility changes, primarily a security/UX improvement.

---
*PR created automatically by Jules for task [4026055634150872996](https://jules.google.com/task/4026055634150872996) started by @ManupaKDU*