### PR TITLE
🎨 Palette: Fix keyboard accessibility for accordion menus

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -631,7 +631,14 @@
       }
 
       .menu-action {
-        display: none;
+        opacity: 0;
+        position: absolute;
+      }
+
+      .menu-action:focus-visible ~ .nav-toggle {
+        outline: 2px solid var(--buttonActive);
+        outline-offset: 2px;
+        border-radius: 4px;
       }
 
       .menu-action + label + div {


### PR DESCRIPTION
💡 What: Replaced `display: none;` with `opacity: 0; position: absolute;` on `.menu-action` checkboxes and added a visual focus outline for their sibling `.nav-toggle` labels.

🎯 Why: Hiding checkboxes using `display: none` completely removes them from the accessibility tree, making it impossible to navigate accordion menus using the keyboard. This allows the hidden input to capture focus and visually indicate it on the menu header.

📸 Before/After: The menu headers (like "Camera Control" or "Picture Settings") now show a clear green focus ring when navigating through them via the `Tab` key, whereas before they were completely skipped.

♿ Accessibility: Restores critical keyboard navigation and focus-visibility to all collapsible menu panels in the UI, compliant with WCAG guidelines for custom toggles.

---
*PR created automatically by Jules for task [14706032760595947890](https://jules.google.com/task/14706032760595947890) started by @ManupaKDU*