### PR TITLE
🎨 Palette: Make menu toggles accessible to keyboard navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -34,3 +34,7 @@
 ## 2024-04-08 - [Hide Password Inputs]
 **Learning:** Found that multiple sensitive configuration fields (WiFi, FTP, SMTP, and Web passwords) in `Auxil.htm` and `MJPEG2SD.htm` were using the default `text` type, leaving them visible on screen and potentially vulnerable to shoulder-surfing.
 **Action:** Always verify that newly added or existing sensitive input fields explicitly use `type="password"`.
+
+## 2024-05-20 - Explicit Adjacent Sibling Selectors for Toggles
+**Learning:** In `data/MJPEG2SD.htm` and `data/Auxil.htm`, `.menu-action` checkboxes are separated from their `.nav-toggle` labels by a `.pin-menu` div. While CSS rules linking checkbox focus state to the label should use `~` (e.g., `.menu-action:focus-visible ~ .nav-toggle`), rules targeting the content div for visibility toggling must use the explicit adjacent chain (e.g., `.menu-action + .pin-menu + label + div`) rather than `~ label + div` to avoid inadvertently hiding subsequent unrelated menu sections.
+**Action:** When updating CSS selectors where the HTML structure has changed (like the addition of `.pin-menu`), strictly map the `+` adjacent selectors to the new structure rather than converting them to `~` general sibling selectors for structure-dependent display logic.


### PR DESCRIPTION
💡 What: Made the hidden custom checkboxes for menu toggles focusable by replacing `display: none;` with `opacity: 0; position: absolute;`. Added a `:focus-visible` focus ring to the label to indicate focus state. Also fixed the CSS toggle visibility logic to properly account for the `.pin-menu` element.
🎯 Why: Keyboard users could not navigate or focus the menu toggle switches because `display: none` removes the input from the accessibility tree.
📸 Before/After: The menu items now correctly display a distinct green focus ring when navigating via the Tab key.
♿ Accessibility: Ensures custom toggle switches are in the keyboard focus order and visibly indicate focus.

---
*PR created automatically by Jules for task [15377064111482987079](https://jules.google.com/task/15377064111482987079) started by @ManupaKDU*