### PR TITLE
🎨 Palette: Add labels to dynamically generated radio buttons

### DIFF
--- a/data/common.js
+++ b/data/common.js
@@ -815,7 +815,9 @@
                       valCntr = 0;
                       inputHtml = '';
                       value.substring(2).split(":").forEach(opt => {
-                        inputHtml += opt + '<input type="radio" class="configItem" name="' + saveKey + '" value="' + valCntr +
+                        let radioId = valCntr === 0 ? saveKey : saveKey + '_' + valCntr;
+                        inputHtml += '<label for="' + radioId + '">' + opt + '</label>' +
+                          '<input type="radio" id="' + radioId + '" class="configItem" name="' + saveKey + '" value="' + valCntr +
                           (saveVal == valCntr ? '" checked>' : '">');
                         valCntr++;
                       });


### PR DESCRIPTION
💡 What: Wrap text options for dynamically generated radio button groups in `<label>` elements linking via `for` and `id` attributes.
🎯 Why: Previously, text options were just plain text next to the inputs, meaning they couldn't be clicked to select the option. Wrapping them in a `<label>` increases the click target area and makes the interface more intuitive to interact with on touch and mouse devices.
📸 Before/After: Before: `<input type="radio" ...> Option 1`. After: `<label for="setting1_0">Option 1</label><input type="radio" id="setting1_0" ...>`.
♿ Accessibility: The addition of `<label for="[id]">` provides accessible names for the screen readers and allows keyboard users and users relying on assistive technology to better understand the inputs they are interacting with.

---
*PR created automatically by Jules for task [3461760115792191449](https://jules.google.com/task/3461760115792191449) started by @ManupaKDU*