### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in query parameter parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@
 **Vulnerability:** The `checkAuth` method in `webServer.cpp` blindly added +1 to the `Authorization` header length (even when absent, causing uninitialized read) and validated basic credentials using a loose `strstr(auth, encode64(credentials))`, allowing potential authentication bypasses if the encoded string were embedded in another structure.
 **Learning:** Adding 1 to a 0 length creates a 1 byte array that then fails to be populated but is read by a string function. Furthermore, loose authentication checks like `strstr` are inherently flawed for security tokens since they don't ensure the token matches exactly and fully, only that it is contained.
 **Prevention:** Always verify header length > 0 before allocating stack memory and reading into it. Always validate security tokens using exact strict matches (e.g. `strcmp`) against the full expected value format, including prefixes (like "Basic ").
+
+## 2024-04-14 - Fix Buffer Overflow Risk in HTTP Query Parsing
+**Vulnerability:** A classic buffer overflow risk existed in `webServer.cpp` where `strcpy(value, variable + strlen(variable) + 1)` was used to extract query parameter values into a statically sized `value` buffer (`IN_FILE_NAME_LEN`).
+**Learning:** In resource-constrained C/C++ environments, developers sometimes use unsafe string functions like `strcpy` for convenience or perceived performance, overlooking the risk of untrusted HTTP input exceeding buffer limits.
+**Prevention:** Always use bounded string copy functions like `strncpy(dest, src, max_size)` and immediately followed by `dest[max_size - 1] = '\0'` to guarantee null-termination, or better yet, use robust string classes or `snprintf` if applicable.

--- a/webServer.cpp
+++ b/webServer.cpp
@@ -175,7 +175,8 @@ esp_err_t extractQueryKeyVal(httpd_req_t *req, char* variable, char* value) {
   char* endPtr = strchr(variable, '=');
   if (endPtr != NULL) {
     *endPtr = 0; // split variable into 2 strings, first is key name
-    strcpy(value, variable + strlen(variable) + 1); // value is now second part of string
+    strncpy(value, variable + strlen(variable) + 1, IN_FILE_NAME_LEN - 1); // value is now second part of string
+    value[IN_FILE_NAME_LEN - 1] = 0; // ensure null termination
     if (isPathTraversal(variable) || isPathTraversal(value)) {
       LOG_WRN("Path traversal attempt detected in query string");
       httpd_resp_set_status(req, "400 Bad Request");
@@ -248,7 +249,8 @@ static esp_err_t controlHandler(httpd_req_t *req) {
   if (extractQueryKeyVal(req, variable, value) != ESP_OK) return ESP_FAIL;
   if (!strcmp(variable, "displayLog")) displayLog(req);
   else {
-    strcpy(value, variable + strlen(variable) + 1); // value points to second part of string
+    strncpy(value, variable + strlen(variable) + 1, IN_FILE_NAME_LEN - 1); // value points to second part of string
+    value[IN_FILE_NAME_LEN - 1] = 0; // ensure null termination
     if (!strcmp(variable, "reset")) {
       httpd_resp_sendstr(req, NULL); // stop browser resending reset
       doRestart(value);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A buffer overflow vulnerability existed in `webServer.cpp` due to the use of `strcpy` to copy untrusted query parameter values into a fixed-size buffer (`value` array bounded by `IN_FILE_NAME_LEN`).
🎯 Impact: A remote attacker could potentially trigger memory corruption, denial of service (DoS), or potentially execute arbitrary code by sending a crafted HTTP request with an overly long query parameter value.
🔧 Fix: Replaced `strcpy` with `strncpy(..., IN_FILE_NAME_LEN - 1)` and explicitly set the null-terminator `value[IN_FILE_NAME_LEN - 1] = 0` to ensure safe bounds checking.
✅ Verification: Ran `cppcheck` to verify no new errors were introduced and manually reviewed the code to ensure bounded buffer writes.

---
*PR created automatically by Jules for task [7504672242729419016](https://jules.google.com/task/7504672242729419016) started by @ManupaKDU*