### PR TITLE
🎨 Palette: Add confirmation dialog to Delete All button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2025-04-21 - [Fix Accordion Menu Toggling]
 **Learning:** [In `data/MJPEG2SD.htm` and `data/Auxil.htm`, `.menu-action` checkboxes are separated from their `.nav-toggle` labels by a `.pin-menu` div. While CSS rules linking checkbox focus state to the label should use `~` (e.g., `.menu-action:focus-visible ~ .nav-toggle`), rules targeting the content div for visibility toggling must use the explicit adjacent chain (e.g., `.menu-action + .pin-menu + label + div`) rather than `~ label + div` to avoid inadvertently hiding subsequent unrelated menu sections.]
 **Action:** [When modifying UI templates with custom checkbox-based accordions or menus, strictly verify adjacent vs general sibling CSS selectors to ensure intermediate injected DOM elements (like pins or icons) don't silently break expand/collapse functionality.]
+
+## 2026-04-24 - Protecting Destructive Actions with Confirmation Dialogs
+**Learning:** Destructive actions like clearing all local storage IPs lacked a confirmation step, potentially leading to accidental data loss with a single misclick.
+**Action:** Always wrap destructive actions in `window.confirm()` dialogs to ensure intentionality before irreversible changes occur.

--- a/data/common.js
+++ b/data/common.js
@@ -982,9 +982,10 @@
 
       // Function to clear local storage
       function clearLocalStorage() {
-        const ipAddresses = localStorage.getItem('enteredIPs') ? JSON.parse(localStorage.getItem('enteredIPs')) : [];
-        localStorage.removeItem('enteredIPs');
-        createImageElements(ipAddresses); // Update images after clearing local storage
+        if (window.confirm('This will delete all saved IP addresses. Are you sure?')) {
+          localStorage.removeItem('enteredIPs');
+          createImageElements([]); // Update images after clearing local storage
+        }
       }
 
       // Retrieve and populate the input field with the saved IPs on page load


### PR DESCRIPTION
💡 What: Added a `window.confirm()` dialog to the `clearLocalStorage` function.
🎯 Why: Prevents users from accidentally deleting all their saved IP configurations with a single misclick on the "Delete All" button.
📸 Before/After: No visual change to the main interface, but clicking the button now presents a standard browser confirmation dialog.
♿ Accessibility: N/A - Standard browser alert dialog.

---
*PR created automatically by Jules for task [6388411644203613391](https://jules.google.com/task/6388411644203613391) started by @ManupaKDU*