### PR TITLE
🎨 Palette: Add confirmation dialog when deleting all cameras from Hub

### DIFF
--- a/data/common.js
+++ b/data/common.js
@@ -982,9 +982,11 @@
 
       // Function to clear local storage
       function clearLocalStorage() {
-        const ipAddresses = localStorage.getItem('enteredIPs') ? JSON.parse(localStorage.getItem('enteredIPs')) : [];
-        localStorage.removeItem('enteredIPs');
-        createImageElements(ipAddresses); // Update images after clearing local storage
+        if (window.confirm('This will remove all saved cameras from the Hub. Are you sure?')) {
+          const ipAddresses = localStorage.getItem('enteredIPs') ? JSON.parse(localStorage.getItem('enteredIPs')) : [];
+          localStorage.removeItem('enteredIPs');
+          createImageElements(ipAddresses); // Update images after clearing local storage
+        }
       }
 
       // Retrieve and populate the input field with the saved IPs on page load


### PR DESCRIPTION
💡 What: Added a `window.confirm` dialog prompt to the `clearLocalStorage` function which is called when the "Delete All" button is clicked in the Camera Hub.
🎯 Why: Wiping out all locally saved camera IPs is a destructive action that previously happened instantly without any warning, causing potential data loss and frustration for users.
📸 Before/After: Before, clicking "Delete All" silently wiped all camera connections. Now, it prompts the user with "This will remove all saved cameras from the Hub. Are you sure?"
♿ Accessibility: Improved cognitive accessibility and user safety by confirming destructive actions before execution.

---
*PR created automatically by Jules for task [16874341667380467840](https://jules.google.com/task/16874341667380467840) started by @ManupaKDU*