### PR TITLE
🎨 Palette: Add confirmation for deleting all Camera Hub entries

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2025-04-21 - [Fix Accordion Menu Toggling]
 **Learning:** [In `data/MJPEG2SD.htm` and `data/Auxil.htm`, `.menu-action` checkboxes are separated from their `.nav-toggle` labels by a `.pin-menu` div. While CSS rules linking checkbox focus state to the label should use `~` (e.g., `.menu-action:focus-visible ~ .nav-toggle`), rules targeting the content div for visibility toggling must use the explicit adjacent chain (e.g., `.menu-action + .pin-menu + label + div`) rather than `~ label + div` to avoid inadvertently hiding subsequent unrelated menu sections.]
 **Action:** [When modifying UI templates with custom checkbox-based accordions or menus, strictly verify adjacent vs general sibling CSS selectors to ensure intermediate injected DOM elements (like pins or icons) don't silently break expand/collapse functionality.]
+
+## 2024-05-20 - Confirmations for Destructive Actions
+**Learning:** Found that a destructive action (clearing all saved IP addresses from the Camera Hub's local storage) was performed immediately upon clicking a "Delete All" button without any confirmation dialog. This can lead to accidental data loss.
+**Action:** Always wrap custom destructive actions (e.g., clearing local storage) in `window.confirm()` dialogs to prevent accidental data loss and improve the overall UX.

--- a/data/common.js
+++ b/data/common.js
@@ -982,9 +982,11 @@
 
       // Function to clear local storage
       function clearLocalStorage() {
-        const ipAddresses = localStorage.getItem('enteredIPs') ? JSON.parse(localStorage.getItem('enteredIPs')) : [];
-        localStorage.removeItem('enteredIPs');
-        createImageElements(ipAddresses); // Update images after clearing local storage
+        if (window.confirm("Are you sure you want to delete all saved IP addresses?")) {
+          const ipAddresses = localStorage.getItem('enteredIPs') ? JSON.parse(localStorage.getItem('enteredIPs')) : [];
+          localStorage.removeItem('enteredIPs');
+          createImageElements(ipAddresses); // Update images after clearing local storage
+        }
       }
 
       // Retrieve and populate the input field with the saved IPs on page load


### PR DESCRIPTION
💡 What: Added a `window.confirm` dialog to the `clearLocalStorage` function in the Camera Hub interface.
🎯 Why: Clicking the "Delete All" button immediately removed all saved device IP addresses without warning. This UX enhancement adds a safety friction step to prevent accidental data loss.
📸 Before/After: A standard browser confirmation dialog now appears when "Delete All" is clicked.
♿ Accessibility: Ensures that destructive actions have an explicit user confirmation step.

---
*PR created automatically by Jules for task [16902493179121492074](https://jules.google.com/task/16902493179121492074) started by @ManupaKDU*