### PR TITLE
🎨 Palette: [Make dynamically generated Camera Hub tiles accessible and safe]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,7 @@
 ## 2024-05-20 - Confirmations for Destructive Actions
 **Learning:** Found that a destructive action (clearing all saved IP addresses from the Camera Hub's local storage) was performed immediately upon clicking a "Delete All" button without any confirmation dialog. This can lead to accidental data loss.
 **Action:** Always wrap custom destructive actions (e.g., clearing local storage) in `window.confirm()` dialogs to prevent accidental data loss and improve the overall UX.
+
+## 2025-02-18 - Dynamically Generated Keyboard Accessible Tiles
+**Learning:** When generating interactive tiles or buttons using `div` or `span` elements via JavaScript (like the device hub camera tiles), it is crucial to explicitly add `role="button"`, `tabindex="0"`, and `aria-label` to ensure they are discovered and operable by assistive technologies. Additionally, destructive actions (like removing an item) should be wrapped in confirmation dialogs (e.g., `window.confirm`) to prevent accidental data loss. Furthermore, for non-native interactive elements (e.g. `div`), assigning an `onclick` handler does not automatically provide keyboard support; you must explicitly add an `onkeydown` handler to intercept the `Enter` and `Space` keys to trigger the action.
+**Action:** Always verify that dynamically created interactive elements implement proper ARIA roles and keyboard event handlers, and ensure that data removal flows include a confirmation step.

--- a/data/common.js
+++ b/data/common.js
@@ -887,30 +887,6 @@
           // Create a container div for each image
           const ipContainer = document.createElement('div');
           ipContainer.classList.add('ipContainer');
-          // Create an image element
-          const hubImg = document.createElement('img');
-          hubImg.classList.add('hubImg');
-          // Set the source attribute to request image
-          hubImg.src = `http://${ip}`;
-          // Set an alt attribute for accessibility
-          hubImg.alt = `No Image`;
-
-          // Create a remove button for each container
-          const removeButton = document.createElement('span');
-          removeButton.classList.add('removeButton');
-          removeButton.classList.add('iconSize');
-          removeButton.setAttribute('role', 'button');
-          removeButton.setAttribute('tabindex', '0');
-          removeButton.setAttribute('aria-label', 'Remove IP');
-          removeButton.innerHTML = '×';
-          removeButton.onclick = function (event) {
-            event.stopPropagation(); // Prevent container click from triggering at the same time
-            // Remove the IP from local storage, remove the IP container, and update images
-            const updatedIPs = removeFromLocalStorage(ip);
-            container.removeChild(ipContainer);
-            createImageElements(updatedIPs);
-          };
-
           // Create a text element to display the IP address overlay
           const ipUrl = document.createElement('span');
           ipUrl.classList.add('ipUrl');
@@ -922,6 +898,42 @@
           const index = ip.indexOf('/');
           if (index !== -1) ipStr = ip.substring(0, index);
           ipText.textContent = ipStr;
+
+          ipContainer.setAttribute('role', 'button');
+          ipContainer.setAttribute('tabindex', '0');
+          ipContainer.setAttribute('aria-label', `Open device hub for ${ipStr}`);
+
+          // Create an image element
+          const hubImg = document.createElement('img');
+          hubImg.classList.add('hubImg');
+          // Set the source attribute to request image
+          hubImg.src = `http://${ip}`;
+          // Set an alt attribute for accessibility
+          hubImg.alt = `Camera feed from ${ipStr}`;
+
+          // Create a remove button for each container
+          const removeButton = document.createElement('span');
+          removeButton.classList.add('removeButton');
+          removeButton.classList.add('iconSize');
+          removeButton.setAttribute('role', 'button');
+          removeButton.setAttribute('tabindex', '0');
+          removeButton.setAttribute('aria-label', `Remove IP ${ipStr}`);
+          removeButton.innerHTML = '×';
+          removeButton.onclick = function (event) {
+            event.stopPropagation(); // Prevent container click from triggering at the same time
+            if (window.confirm(`Are you sure you want to remove ${ipStr}?`)) {
+              // Remove the IP from local storage, remove the IP container, and update images
+              const updatedIPs = removeFromLocalStorage(ip);
+              container.removeChild(ipContainer);
+              createImageElements(updatedIPs);
+            }
+          };
+          removeButton.onkeydown = function(event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              removeButton.click();
+            }
+          };
 
           // Append the image, IP text, and remove button to the container
           ipContainer.appendChild(ipUrl);
@@ -935,6 +947,12 @@
           // Add click event listener to each container for fetching the web page for the IP address
           ipContainer.onclick = function () {
             window.open(`http://${ipStr}`, '_blank');
+          };
+          ipContainer.onkeydown = function(event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              ipContainer.click();
+            }
           };
 
           // Append the container to the main image container


### PR DESCRIPTION
💡 What: Improved the accessibility and safety of the dynamically generated camera hub tiles in `data/common.js`.
🎯 Why: Keyboard users and screen readers were previously unable to interact with or understand the device tiles or delete buttons properly because they lacked necessary ARIA attributes and keyboard event handlers. Additionally, clicking "delete" immediately removed the tile without confirmation, causing accidental data loss.
📸 Before/After: The tiles now properly support the `Tab` key, `Enter`, and `Space`, and display a `window.confirm` dialog before deletion. Screen readers will now read accurate labels for the buttons and images.
♿ Accessibility: Added `role="button"`, `tabindex="0"`, dynamic `aria-label`s, and explicitly mapped `Enter` and `Space` keystrokes to the click handler to make these custom elements completely accessible.

---
*PR created automatically by Jules for task [1463008485851754053](https://jules.google.com/task/1463008485851754053) started by @ManupaKDU*