### PR TITLE
🎨 Palette: Improve IP Hub interaction and accessibility

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1714,7 +1714,7 @@
       <div id="buttonContainer">
         <!-- Input field for users to enter individual IPs -->
         <label for="ipInput">Enter IP address:&nbsp;</label>
-        <input type="text" id="ipInput" class="local">
+        <input type="text" id="ipInput" class="local" placeholder="e.g. 192.168.1.100">
         <button id="addIpButton" class="local" onclick="addIP()">Add IP</button>
         <button id="clearStorageButton" class="local" onclick="clearLocalStorage()">Delete All</button>
         <button id="refreshAllButton" class="local" onclick="refreshAllContainers(true)">Refresh</button>

--- a/data/common.js
+++ b/data/common.js
@@ -624,6 +624,12 @@
             if (event.target.id == 'txtCmd') {
               if (keyPress == 13) sendWsCmd();
             }
+            if (event.target.id == 'ipInput') {
+              if (keyPress == 13) {
+                event.preventDefault();
+                addIP();
+              }
+            }
             // trigger click for elements with role="button" or SVG rects when Enter or Space is pressed
             if (keyPress === 13 || keyPress === 32) {
               const e = event.target;
@@ -884,9 +890,16 @@
 
         // Convert the array of IP addresses into individual IPs
         for (const ip of ipAddresses) {
+          let ipStr = ip;
+          const index = ip.indexOf('/');
+          if (index !== -1) ipStr = ip.substring(0, index);
+
           // Create a container div for each image
           const ipContainer = document.createElement('div');
           ipContainer.classList.add('ipContainer');
+          ipContainer.setAttribute('role', 'button');
+          ipContainer.setAttribute('tabindex', '0');
+          ipContainer.setAttribute('aria-label', `Open camera at ${ipStr}`);
           // Create an image element
           const hubImg = document.createElement('img');
           hubImg.classList.add('hubImg');
@@ -918,9 +931,6 @@
           ipUrl.style.display = 'none';
           const ipText = document.createElement('span');
           ipText.classList.add('ipText');
-          let ipStr = ip;
-          const index = ip.indexOf('/');
-          if (index !== -1) ipStr = ip.substring(0, index);
           ipText.textContent = ipStr;
 
           // Append the image, IP text, and remove button to the container


### PR DESCRIPTION
💡 What:
- Added a helpful `placeholder` ("e.g. 192.168.1.100") to the IP input field in the Device Hub tab.
- Enabled submitting the IP address by pressing the `Enter` key on the input field.
- Added accessibility attributes (`role="button"`, `tabindex="0"`, `aria-label="Open camera at [IP]"`) to the dynamically generated IP container items so they can be triggered by keyboard and read by screen readers.

🎯 Why:
- Without a placeholder, users might not know the exact format to enter the remote IP.
- Without Enter key support, users are forced to move from the keyboard to the mouse to click the "Add IP" button, breaking keyboard navigation flow.
- The generated IP links act as buttons but were rendered as simple `<div>` elements without tab focus or ARIA roles, making them completely inaccessible to keyboard-only or screen reader users.

📸 Before/After:
Before: `ipInput` had no placeholder. Users had to manually click "Add IP". The IP containers could only be clicked with a mouse.
After: `ipInput` suggests a format and accepts "Enter" key presses. The IP containers can be tabbed to and activated with Enter/Space.

♿ Accessibility:
- Added `role="button"` and `tabindex="0"` to the IP links, hooking into the app's existing global keydown listener.
- Added a dynamic `aria-label` that reads "Open camera at [IP]".

---
*PR created automatically by Jules for task [10502760518087078549](https://jules.google.com/task/10502760518087078549) started by @ManupaKDU*