### PR TITLE
🎨 Palette: Keep dynamic ARIA labels synchronized with visual button states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,7 @@
 ## 2024-05-20 - Confirmations for Destructive Actions
 **Learning:** Found that a destructive action (clearing all saved IP addresses from the Camera Hub's local storage) was performed immediately upon clicking a "Delete All" button without any confirmation dialog. This can lead to accidental data loss.
 **Action:** Always wrap custom destructive actions (e.g., clearing local storage) in `window.confirm()` dialogs to prevent accidental data loss and improve the overall UX.
+
+## 2026-05-02 - Keep dynamic ARIA labels synchronized with visual text updates
+**Learning:** When JavaScript dynamically updates the visual text of an interactive element (e.g., changing 'Start Recording' to 'Stop Recording' on a button), the `aria-label` (if present) is NOT automatically updated. If the element relies on `aria-label` to mask unicode icons or provide a clean accessible name, screen readers will announce the old state, causing severe confusion.
+**Action:** When updating the `.innerHTML` or `.textContent` of an element to reflect a state change, always check if the element has an `aria-label`. If it does, ensure you also call `.setAttribute('aria-label', ...)` with the new accessible name to keep it synchronized with the visual state.

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -944,7 +944,7 @@
             <li><button id="forceRecord" aria-label="Start Recording" style="float:right;">➤&nbsp;Start Recording</button></li>
             <li><div class="sep"></div></li>
             <li><button id="forceStream" aria-label="Start Stream" class="local" style="float:right;">➤&nbsp;Start Stream</button></li>
-            <li><button id="get-still" class="local" style="float:right;">Get Still</button></li>
+            <li><button id="get-still" class="local" style="float:right;" title="Capture a still image" aria-label="Capture a still image">Get Still</button></li>
             <li><div class="sep"></div></li>
             <li><button id="forcePlayback" aria-label="Start Playback" class="local disabled" style="float:right;" title="Select a video in 'Playback & File Transfers' to activate playback.">➤&nbsp;Start Playback</button></li>
           </ul>
@@ -2051,6 +2051,7 @@
             stopAll("activatePlaybackButton");
             playbackButton.classList.add("active");
             playbackButton.innerHTML = "▢&nbsp;Stop Playback";
+            playbackButton.setAttribute("aria-label", "Stop Playback");
             playbackButton.classList.add("blinking");
             if (await checkTask('/sustain?playback=0')) {
               view.src = webServer + '/sustain?playback=0';
@@ -2065,6 +2066,7 @@
       function deactivatePlaybackButton(sendStop = true) {
         playbackButton.classList.remove("active");
         playbackButton.innerHTML = "➤&nbsp;Start Playback";
+        playbackButton.setAttribute("aria-label", "Start Playback");
         playbackButton.classList.remove("blinking");
         disable(playbackButton);
         stopAll("deactivatePlaybackButton");
@@ -2075,6 +2077,7 @@
         if (!recordButton.classList.contains("active")) {
           recordButton.classList.add("active");
           recordButton.innerHTML = "▢&nbsp;Stop Recording";
+          recordButton.setAttribute("aria-label", "Stop Recording");
         }
         if (isHidden(recordingIndicator)) {
           show(recordingIndicator);
@@ -2085,6 +2088,7 @@
       function deactivateRecordButton() {
         recordButton.classList.remove("active");
         recordButton.innerHTML = "➤&nbsp;Start Recording";
+        recordButton.setAttribute("aria-label", "Start Recording");
         recordingIndicator.classList.remove("blinking");
         hide(recordingIndicator);
       }
@@ -2100,6 +2104,7 @@
         stopAll("activateStreamButton");
         streamButton.classList.add("active");
         streamButton.innerHTML = "▢&nbsp;Stop Stream";
+        streamButton.setAttribute("aria-label", "Stop Stream");
         streamButton.classList.add('blinking');
         showRC ? show($('#RCenable')) : hide($('#RCenable'));
         if (await checkTask('/sustain?stream=0')) {
@@ -2111,6 +2116,7 @@
       function deactivateStreamButton(sendStop = true) {
         streamButton.classList.remove("active");
         streamButton.innerHTML ="➤&nbsp;Start Stream";
+        streamButton.setAttribute("aria-label", "Start Stream");
         streamButton.classList.remove('blinking');
         stopAll("deactivateStreamButton");
         if (sendStop) sendAll("stopStream", "0");


### PR DESCRIPTION
💡 What: Ensure dynamic `aria-label`s are updated alongside visual changes in `MJPEG2SD.htm`, and added a missing tooltip to the `Get Still` button.
🎯 Why: When button text is updated dynamically via `.innerHTML` (e.g. from `Start Recording` to `Stop Recording`), screen readers continue announcing the initial `aria-label` text. This ensures screen readers always announce the accurate state.
📸 Before/After: Visuals are completely unchanged.
♿ Accessibility: Ensures correct vocalization for screen readers interacting with dynamically changing UI buttons.

---
*PR created automatically by Jules for task [7730114973106417192](https://jules.google.com/task/7730114973106417192) started by @ManupaKDU*