### PR TITLE
⚡ Bolt: Optimize in-place string splitting overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,6 @@
 ## 2024-06-25 - Avoid O(N^2) strlen overhead in formatting loops
 **Learning:** Calling `strlen()` to find the end of a buffer inside a loop (e.g. `sprintf(buf + strlen(buf), ...)`) causes an O(N^2) performance hit because it has to traverse the entire string on each iteration.
 **Action:** Maintain an `offset` variable and use `offset += snprintf(buf + offset, size - offset, ...)` to concatenate strings in O(N) time.
+## 2024-05-03 - String Pointer Optimization
+**Learning:** In C/C++ applications on the ESP32, repeatedly calculating string offsets with `strlen()` during in-place string splitting loops introduces an unnecessary O(N) performance penalty.
+**Action:** When a pointer to a split character (e.g., via `strchr()`) is already computed and bounded, use pointer arithmetic (`endPtr + 1`) to advance to the remainder of the string instead of re-calculating the length (`variable + strlen(variable) + 1`).

--- a/appSpecific.cpp
+++ b/appSpecific.cpp
@@ -305,7 +305,7 @@ static bool extractKeyVal(const char* wsMsg) {
   char* endPtr = strchr(variable, '=');
   if (endPtr != NULL) {
     *endPtr = 0; // split variable into 2 strings, first is key name
-    strncpy(value, variable + strlen(variable) + 1, FILE_NAME_LEN - 1); // value is now second part of string
+    strncpy(value, endPtr + 1, FILE_NAME_LEN - 1); // value is now second part of string
     value[FILE_NAME_LEN - 1] = 0; // ensure null termination
     return true;
   } else LOG_ERR("Invalid query string: %s", wsMsg);

--- a/webServer.cpp
+++ b/webServer.cpp
@@ -175,7 +175,7 @@ esp_err_t extractQueryKeyVal(httpd_req_t *req, char* variable, char* value, size
   char* endPtr = strchr(variable, '=');
   if (endPtr != NULL) {
     *endPtr = 0; // split variable into 2 strings, first is key name
-    strncpy(value, variable + strlen(variable) + 1, valueSize - 1); // value is now second part of string
+    strncpy(value, endPtr + 1, valueSize - 1); // value is now second part of string, avoiding redundant strlen
     value[valueSize - 1] = 0; // ensure null termination
     if (isPathTraversal(variable) || isPathTraversal(value)) {
       LOG_WRN("Path traversal attempt detected in query string");
@@ -249,8 +249,7 @@ static esp_err_t controlHandler(httpd_req_t *req) {
   if (extractQueryKeyVal(req, variable, value, sizeof(value)) != ESP_OK) return ESP_FAIL;
   if (!strcmp(variable, "displayLog")) displayLog(req);
   else {
-    strncpy(value, variable + strlen(variable) + 1, IN_FILE_NAME_LEN - 1); // value points to second part of string
-    value[IN_FILE_NAME_LEN - 1] = 0; // ensure null termination
+    // extractQueryKeyVal already populated value
     if (!strcmp(variable, "reset")) {
       httpd_resp_sendstr(req, NULL); // stop browser resending reset
       doRestart(value);


### PR DESCRIPTION
💡 What: Avoids O(N) `strlen()` scans in query string extraction logic by leveraging the offset discovered by `strchr`.
🎯 Why: In-place string splitting loops were repeatedly traversing strings to find their length immediately after a pointer to the delimiter was obtained, resulting in unnecessary CPU overhead on string operations on the ESP32.
📊 Impact: Decreases computational overhead when splitting long request URLs and parameters, improving real-time HTTP server responsiveness.
🔬 Measurement: Verified using `cppcheck` to ensure memory safety. Code functionality remains identical.

---
*PR created automatically by Jules for task [3367973772598734909](https://jules.google.com/task/3367973772598734909) started by @ManupaKDU*