### PR TITLE
⚡ Bolt: Fix O(N^2) strlen overhead in backtrace formatting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,6 @@
 ## 2024-06-25 - Avoid O(N^2) strlen overhead in formatting loops
 **Learning:** Calling `strlen()` to find the end of a buffer inside a loop (e.g. `sprintf(buf + strlen(buf), ...)`) causes an O(N^2) performance hit because it has to traverse the entire string on each iteration.
 **Action:** Maintain an `offset` variable and use `offset += snprintf(buf + offset, size - offset, ...)` to concatenate strings in O(N) time.
+## 2025-02-13 - O(N^2) strlen overhead in backtrace string formatting
+**Learning:** Calling `strlen()` to find the end of a buffer inside a formatting loop (e.g., `snprintf(bt + strlen(bt), ...)`) causes an O(N^2) performance hit because it has to traverse the entire string on each iteration (Schlemiel the Painter's Algorithm).
+**Action:** Always maintain an explicit `offset` tracker variable and use `offset += snprintf(bt + offset, size - offset, ...)` to concatenate strings in O(1) time per iteration, along with proper bounds checking `if (written > 0 && written < (int)(size - offset))`.

--- a/utils.cpp
+++ b/utils.cpp
@@ -1317,8 +1317,15 @@ static void showBacktrace() {
     sprintf(bt, "%s on core %d", btReason, btCore);
     LOG_WRN("%s", bt);
     bt[0] = 0;
+    int offset = 0;
+    // Bolt: Cache length using pointer offset to prevent O(N^2) strlen recalculation inside loop
     for (int i = 0; i < btLen; i++) {
-      snprintf(bt + strlen(bt), sizeof(bt) - strlen(bt) - 11, "0x%08x ", (unsigned int)backtrace[i]); // 11 is size of new trace hex
+      int written = snprintf(bt + offset, sizeof(bt) - offset, "0x%08x ", (unsigned int)backtrace[i]);
+      if (written > 0 && written < (int)(sizeof(bt) - offset)) {
+        offset += written;
+      } else {
+        break; // Buffer is full or error occurred
+      }
     }
     LOG_WRN("Paste backtrace below into Arduino Exception Decoder:\n");
     logPrint("Backtrace: %s\n\n", bt);


### PR DESCRIPTION
💡 What: Replaced O(N^2) `strlen()` recalculation inside a loop with an explicit O(1) `offset` tracking variable during backtrace string formatting in `utils.cpp`.
🎯 Why: `strlen()` was being called on every loop iteration to find the end of the buffer for `snprintf`, which causes an O(N^2) performance hit (Schlemiel the Painter's Algorithm). Using an offset variable and bounds checking fixes this and correctly prevents buffer overflows.
📊 Impact: Reduces time complexity of backtrace string concatenation from O(N^2) to O(N), saving CPU cycles when logging crashes.
🔬 Measurement: Verified with `cppcheck` that the code introduces no buffer overflows and correctly utilizes offset variables safely. Tested against local bounds-checking rules.

---
*PR created automatically by Jules for task [1441989746952948232](https://jules.google.com/task/1441989746952948232) started by @ManupaKDU*