### PR TITLE
⚡ Bolt: Optimize backtrace string concatenation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,6 @@
 ## 2024-06-25 - Avoid O(N^2) strlen overhead in formatting loops
 **Learning:** Calling `strlen()` to find the end of a buffer inside a loop (e.g. `sprintf(buf + strlen(buf), ...)`) causes an O(N^2) performance hit because it has to traverse the entire string on each iteration.
 **Action:** Maintain an `offset` variable and use `offset += snprintf(buf + offset, size - offset, ...)` to concatenate strings in O(N) time.
+## 2024-05-31 - Avoid O(N^2) strlen overhead in formatting loops
+**Learning:** Calling `strlen()` to find the end of a buffer inside a loop (e.g. `snprintf(buf + strlen(buf), ...)`) causes an O(N^2) performance hit because it has to traverse the entire string on each iteration. Furthermore, calculating differences with `sizeof` and `strlen` (e.g., `sizeof(bt) - strlen(bt) - 11`) can silently underflow to `SIZE_MAX` if bounds are exceeded, leading to a critical buffer overflow.
+**Action:** Maintain an `offset` variable and calculate the remaining space (`remaining = sizeof(buf) - offset`). Update the offset safely with `offset += written` inside the loop, and use `snprintf(buf + offset, remaining, ...)` to concatenate strings safely in O(N) time.

--- a/utils.cpp
+++ b/utils.cpp
@@ -1317,8 +1317,16 @@ static void showBacktrace() {
     sprintf(bt, "%s on core %d", btReason, btCore);
     LOG_WRN("%s", bt);
     bt[0] = 0;
+    size_t offset = 0;
     for (int i = 0; i < btLen; i++) {
-      snprintf(bt + strlen(bt), sizeof(bt) - strlen(bt) - 11, "0x%08x ", (unsigned int)backtrace[i]); // 11 is size of new trace hex
+      int remaining = sizeof(bt) - offset - 11; // 11 is size of new trace hex
+      if (remaining <= 0) break;
+      int written = snprintf(bt + offset, remaining, "0x%08x ", (unsigned int)backtrace[i]);
+      if (written > 0 && written < remaining) {
+        offset += written;
+      } else {
+        break;
+      }
     }
     LOG_WRN("Paste backtrace below into Arduino Exception Decoder:\n");
     logPrint("Backtrace: %s\n\n", bt);


### PR DESCRIPTION
💡 What: Replaced the `strlen(bt)` calls inside the `showBacktrace` loop in `utils.cpp` with a tracked `offset` variable. Added rigorous bounds checking to prevent buffer overflows from underflowing `sizeof` subtractions.
🎯 Why: `strlen()` is O(N) complexity; calling it in a loop results in O(N^2) overhead to find the end of the buffer. Additionally, unchecked `sizeof(bt) - strlen(bt)` calculations could overflow buffer size arguments and cause crashes.
📊 Impact: Reduces time complexity of string building in exception decoding from O(N^2) to O(N), guaranteeing safety.
🔬 Measurement: Verified using an isolated C++ trace test program simulating the execution block and boundary edge cases successfully.

---
*PR created automatically by Jules for task [12634993460836239202](https://jules.google.com/task/12634993460836239202) started by @ManupaKDU*