### PR TITLE
⚡ Bolt: Fix O(N^2) strlen overhead in showBacktrace snprintf loop

### DIFF
--- a/utils.cpp
+++ b/utils.cpp
@@ -1317,8 +1317,17 @@ static void showBacktrace() {
     sprintf(bt, "%s on core %d", btReason, btCore);
     LOG_WRN("%s", bt);
     bt[0] = 0;
+    // Track offset to avoid O(N^2) strlen calls
+    int offset = 0;
     for (int i = 0; i < btLen; i++) {
-      snprintf(bt + strlen(bt), sizeof(bt) - strlen(bt) - 11, "0x%08x ", (unsigned int)backtrace[i]); // 11 is size of new trace hex
+      int remaining = sizeof(bt) - offset;
+      if (remaining < 12) break; // Need space for 11 chars + null terminator
+      int written = snprintf(bt + offset, remaining, "0x%08x ", (unsigned int)backtrace[i]);
+      if (written > 0 && written < remaining) {
+        offset += written;
+      } else {
+        break;
+      }
     }
     LOG_WRN("Paste backtrace below into Arduino Exception Decoder:\n");
     logPrint("Backtrace: %s\n\n", bt);


### PR DESCRIPTION
💡 What: Manually tracked string offset in `showBacktrace` string concatenation loop rather than repeatedly calling `strlen()`. Also addressed a theoretical underflow edge case where `sizeof(bt) - strlen(bt) - 11` evaluates to unsigned `size_t`.
🎯 Why: `strlen(bt)` repeatedly scans the entire buffer from the beginning just to append to the end, resulting in an O(N^2) "Schlemiel the Painter" algorithm overhead.
📊 Impact: Expected to reduce processing time and latency spikes when extracting and generating backtraces during panic sequences on the ESP32.
🔬 Measurement: Verify correctness by triggering a system panic and confirming standard string output behavior is still accurate. Code passed cppcheck static analysis locally.

---
*PR created automatically by Jules for task [13674018067412775456](https://jules.google.com/task/13674018067412775456) started by @ManupaKDU*