### PR TITLE
🎨 Palette: Improve disabled state UX and Accessibility

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -121,8 +121,7 @@
       }
 
       .tab button.disabled, input.disabled {
-        cursor: default;
-        pointer-events: none;
+        cursor: not-allowed;
         background: var(--itemInactive)
       }
 
@@ -230,7 +229,7 @@
       }
 
       button:disabled {
-        cursor: default;
+        cursor: not-allowed;
         background: var(--itemInactive)
       }
 
@@ -946,7 +945,7 @@
             <li><button id="forceStream" aria-label="Start Stream" class="local" style="float:right;">➤&nbsp;Start Stream</button></li>
             <li><button id="get-still" class="local" style="float:right;" title="Capture a still image" aria-label="Capture a still image">Get Still</button></li>
             <li><div class="sep"></div></li>
-            <li><button id="forcePlayback" aria-label="Start Playback" class="local disabled" style="float:right;" title="Select a video in 'Playback & File Transfers' to activate playback.">➤&nbsp;Start Playback</button></li>
+            <li><button id="forcePlayback" aria-label="Start Playback" class="local disabled" disabled style="float:right;" title="Select a video in 'Playback & File Transfers' to activate playback.">➤&nbsp;Start Playback</button></li>
           </ul>
         </nav>
       </section>
@@ -964,11 +963,11 @@
                 <nav class="quick-nav" id="picSettings" name="picture-settings" title="Picture Settings" aria-label="Picture Settings" role="button" tabindex="0">📺</nav>
                 <nav class="quick-nav" id="accSettings" name="access-settings" title="Access Settings" aria-label="Access Settings" role="button" tabindex="0">🔧</nav>
                 <div class="micContainer">
-                  <button class="quick-nav audButtons disabled" id="micRem" title="Microphone Control" aria-label="Microphone Control">🎤</button>
+                  <button class="quick-nav audButtons disabled" id="micRem" disabled title="Microphone Control" aria-label="Microphone Control">🎤</button>
                   <canvas id="micLevel" role="meter" aria-label="Microphone volume level"></canvas>
                 </div>
                 <div class="spkrContainer">
-                  <button class="quick-nav audButtons disabled" id="spkrRem" title="Speaker Control" aria-label="Speaker Control">🔈</button>
+                  <button class="quick-nav audButtons disabled" id="spkrRem" disabled title="Speaker Control" aria-label="Speaker Control">🔈</button>
                   <canvas id="spkrLevel" role="meter" aria-label="Speaker volume level"></canvas>
                 </div>
               </nav>

--- a/data/common.js
+++ b/data/common.js
@@ -456,6 +456,7 @@
           const itemInactiveColor =  getComputedStyle(rangeVal).getPropertyValue('--itemInactive');
           rangeVal.style.background = itemInactiveColor;
           el.classList.add('disabled');
+          el.disabled = true;
         }
 
         function enableRangeSlider(el) {;
@@ -463,6 +464,7 @@
           const itemInactiveColor =  getComputedStyle(rangeVal).getPropertyValue('--buttonReady');
           rangeVal.style.background = itemInactiveColor;
           el.classList.remove('disabled');
+          el.disabled = false;
         }
 
         function isActive(el) {


### PR DESCRIPTION
💡 What: Replaced reliance on just a `.disabled` CSS class with the native HTML `disabled` attribute and updated cursor styling to `not-allowed`.
🎯 Why: Elements with only CSS `pointer-events: none` and `cursor: default` offer poor feedback. By using the native `disabled` attribute, elements are completely un-clickable but can still be navigated to by screen readers. The `not-allowed` cursor clearly signals to sighted users that the action is unavailable.
📸 Before/After: Visual changes are subtle, but hover state cursors are improved, and the DOM inspector will now show the `disabled` attribute correctly attached to dynamically disabled elements.
♿ Accessibility: Ensures that visually disabled buttons are natively disabled and prevents screen readers from losing context due to `pointer-events: none`.

---
*PR created automatically by Jules for task [6963485654039264161](https://jules.google.com/task/6963485654039264161) started by @ManupaKDU*