### PR TITLE
⚡ Bolt: Remove redundant strlen traversals and string copies

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,7 @@
 ## 2024-06-25 - Avoid O(N^2) strlen overhead in formatting loops
 **Learning:** Calling `strlen()` to find the end of a buffer inside a loop (e.g. `sprintf(buf + strlen(buf), ...)`) causes an O(N^2) performance hit because it has to traverse the entire string on each iteration.
 **Action:** Maintain an `offset` variable and use `offset += snprintf(buf + offset, size - offset, ...)` to concatenate strings in O(N) time.
+
+## 2024-11-20 - O(N) Performance hit via redundant strlen Calls
+**Learning:** Redundant `strlen(variable)` calls in string extraction paths (e.g., `extractQueryKeyVal` and `appSpecific.cpp`) or in `strncpy` operations are causing redundant string traversal. Instead of using pointer math or recalculating, we can remove the redundant splitting logic completely if the function has already separated them, or use a cached length/direct pointer math like `endPtr + 1`.
+**Action:** Avoid re-splitting strings that have already been separated by `extractQueryKeyVal`, and avoid calling `strlen` repeatedly on the same variable to extract the value if a pointer like `endPtr` is already available from `strchr`.

--- a/appSpecific.cpp
+++ b/appSpecific.cpp
@@ -305,7 +305,7 @@ static bool extractKeyVal(const char* wsMsg) {
   char* endPtr = strchr(variable, '=');
   if (endPtr != NULL) {
     *endPtr = 0; // split variable into 2 strings, first is key name
-    strncpy(value, variable + strlen(variable) + 1, FILE_NAME_LEN - 1); // value is now second part of string
+    strncpy(value, endPtr + 1, FILE_NAME_LEN - 1); // value is now second part of string
     value[FILE_NAME_LEN - 1] = 0; // ensure null termination
     return true;
   } else LOG_ERR("Invalid query string: %s", wsMsg);

--- a/webServer.cpp
+++ b/webServer.cpp
@@ -175,7 +175,7 @@ esp_err_t extractQueryKeyVal(httpd_req_t *req, char* variable, char* value, size
   char* endPtr = strchr(variable, '=');
   if (endPtr != NULL) {
     *endPtr = 0; // split variable into 2 strings, first is key name
-    strncpy(value, variable + strlen(variable) + 1, valueSize - 1); // value is now second part of string
+    strncpy(value, endPtr + 1, valueSize - 1); // value is now second part of string
     value[valueSize - 1] = 0; // ensure null termination
     if (isPathTraversal(variable) || isPathTraversal(value)) {
       LOG_WRN("Path traversal attempt detected in query string");
@@ -249,8 +249,6 @@ static esp_err_t controlHandler(httpd_req_t *req) {
   if (extractQueryKeyVal(req, variable, value, sizeof(value)) != ESP_OK) return ESP_FAIL;
   if (!strcmp(variable, "displayLog")) displayLog(req);
   else {
-    strncpy(value, variable + strlen(variable) + 1, IN_FILE_NAME_LEN - 1); // value points to second part of string
-    value[IN_FILE_NAME_LEN - 1] = 0; // ensure null termination
     if (!strcmp(variable, "reset")) {
       httpd_resp_sendstr(req, NULL); // stop browser resending reset
       doRestart(value);


### PR DESCRIPTION
💡 What: Replaced `strlen(variable)` calls with `endPtr + 1` pointer arithmetic in `webServer.cpp` and `appSpecific.cpp`, and removed a completely redundant `strncpy` block in `controlHandler` that repeated logic already handled by `extractQueryKeyVal`.
🎯 Why: Calling `strlen()` on a string we just split using `strchr` causes an unnecessary O(N) traversal. Furthermore, recalculating and re-copying a value that was already populated by a helper function is wasteful and a source of potential bugs.
📊 Impact: Eliminates O(N) string scans in the HTTP query parser and WebSocket handler hot paths, reducing execution time and overhead.
🔬 Measurement: Verified with `cppcheck` and a standalone host C++ mock test to ensure identical null-termination and offset logic.

---
*PR created automatically by Jules for task [15349581499051663672](https://jules.google.com/task/15349581499051663672) started by @ManupaKDU*