### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix array out-of-bounds in fsTypes/fsPaths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -74,3 +74,7 @@
 **Vulnerability:** In `webServer.cpp` and `appSpecific.cpp`, the codebase extracted substrings by calling `strlen` on a buffer that just had a null-terminator inserted via `strchr` (`variable + strlen(variable) + 1`), and sometimes repeated this extraction redundantly after `extractQueryKeyVal` had already populated the output buffers.
 **Learning:** Using `variable + strlen(variable) + 1` requires O(N) traversal and is less robust than directly using `endPtr + 1` returned by `strchr`. Redundantly repeating this logic after a utility function has already completed the task introduces Out-of-Bounds (OOB) read risks and code duplication.
 **Prevention:** When splitting strings in-place with `strchr`, always use the resulting pointer (e.g., `endPtr + 1`) to calculate the remainder offset. Do not manually extract values immediately after calling utility functions like `extractQueryKeyVal` that already perform the extraction safely.
+## 2026-05-14 - Array Out-Of-Bounds in utilsFS.cpp
+**Vulnerability:** Array out-of-bounds read vulnerability when accessing `fsTypes` and `fsPaths` using `thisFS` when `thisFS` defaults to `TBD`.
+**Learning:** Hardcoded mapping arrays matching an enum need to be the same length as the enum values used to access them, including the default or error states.
+**Prevention:** Extend arrays to cover all enum variants, and use tools like `cppcheck` continuously.

--- a/utilsFS.cpp
+++ b/utilsFS.cpp
@@ -29,8 +29,8 @@ static int sdmmcFreq = BOARD_MAX_SDMMC_FREQ; // board specific default SD_MMC sp
 
 enum fsInd {SDMMC, LITTLEFS, SPIFFSS, TBD};
 static fsInd thisFS = TBD; 
-static const char* fsTypes[] = {"SD_MMC", "LittleFS", "SPIFFS"};
-static const char* fsPaths[] = {"/sdcard", "/littlefs", "/spiffs"};
+static const char* fsTypes[] = {"SD_MMC", "LittleFS", "SPIFFS", "Unknown"};
+static const char* fsPaths[] = {"/sdcard", "/littlefs", "/spiffs", "/"};
 
 // hold sorted list of filenames/folders names in order of newest first
 static std::vector<std::string> fileVec;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Array out-of-bounds read vulnerability in `utilsFS.cpp` when accessing `fsTypes` and `fsPaths` arrays using the `thisFS` index (which can evaluate to `TBD`, equal to `3`, exceeding the array size of `3`).
🎯 Impact: Undefined behavior, potential memory leaks or crashes when reading from unallocated memory blocks if the filesystem state defaults to `TBD` due to mounting failures.
🛠️ Fix: Extended the arrays `fsTypes` and `fsPaths` with the `"Unknown"` and `"/"` elements respectively to safely handle the default `TBD` scenario.
✅ Verification: Ran `cppcheck` to ensure the `arrayIndexOutOfBounds` vulnerability is fully mitigated.

---
*PR created automatically by Jules for task [10382450522159416218](https://jules.google.com/task/10382450522159416218) started by @ManupaKDU*