### PR TITLE
🎨 Palette: Improve form validation with inline ARIA feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -71,3 +71,6 @@
 ## 2024-05-12 - Disabled Cursor Visibility
 **Learning:** `pointer-events: none` completely blocks mouse interactions, which inherently prevents the `cursor: not-allowed` style from rendering when a user hovers over a disabled element. Using this CSS approach alone fails to provide clear visual feedback to mouse users.
 **Action:** Always combine the native HTML `disabled` attribute (managed via JavaScript) with CSS pseudo-selectors (`:disabled` or `.disabled`) containing `cursor: not-allowed`, and explicitly avoid `pointer-events: none` on interactive elements where hover feedback is desired.
+## 2025-02-12 - Inline Form Validation ARIA Feedback
+**Learning:** In `data/common.js`, dynamically generated error messages for inline form validation (`showInputError`) were missing crucial accessibility bindings, leaving screen reader users unaware of the specific input errors.
+**Action:** Always ensure that dynamic error message containers are assigned an ID and `aria-live="polite"`. The corresponding input fields must be dynamically updated with `aria-invalid="true"` and `aria-describedby="[error-id]"` when an error occurs, and these attributes must be removed when the error is resolved.

--- a/data/common.js
+++ b/data/common.js
@@ -395,9 +395,19 @@
             errorEl.classList.add('error-message');
             errorEl.style.color = 'red';
             errorEl.style.fontSize = '0.8em';
+            errorEl.id = inputEl.id + '-error';
+            errorEl.setAttribute('aria-live', 'polite');
             inputEl.parentElement.appendChild(errorEl);
           }
           errorEl.textContent = errorMessage;
+
+          if (errorMessage) {
+            inputEl.setAttribute('aria-invalid', 'true');
+            inputEl.setAttribute('aria-describedby', errorEl.id);
+          } else {
+            inputEl.removeAttribute('aria-invalid');
+            inputEl.removeAttribute('aria-describedby');
+          }
         }
 
         function debounce(func, timeout = 500){


### PR DESCRIPTION
💡 What: Added `aria-live`, `aria-invalid`, and `aria-describedby` properties dynamically when form validation errors occur (e.g. invalid AP password).
🎯 Why: Without these attributes, screen reader users wouldn't be notified when an inline form error appeared, nor would they know which input caused it.
📸 Before/After: N/A - purely semantic change.
♿ Accessibility: Ensures that dynamic error messages are properly announced via `aria-live` and are correctly associated with the offending input fields using `aria-describedby` and `aria-invalid`.

---
*PR created automatically by Jules for task [1484069373875565097](https://jules.google.com/task/1484069373875565097) started by @ManupaKDU*