### PR TITLE
🎨 Palette: Accessible dynamic inline form validation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -71,3 +71,6 @@
 ## 2024-05-12 - Disabled Cursor Visibility
 **Learning:** `pointer-events: none` completely blocks mouse interactions, which inherently prevents the `cursor: not-allowed` style from rendering when a user hovers over a disabled element. Using this CSS approach alone fails to provide clear visual feedback to mouse users.
 **Action:** Always combine the native HTML `disabled` attribute (managed via JavaScript) with CSS pseudo-selectors (`:disabled` or `.disabled`) containing `cursor: not-allowed`, and explicitly avoid `pointer-events: none` on interactive elements where hover feedback is desired.
+## 2024-05-18 - Dynamically Link Error Messages to Inputs
+**Learning:** Screen readers need explicit linking (`aria-describedby`) and live regions (`aria-live`) to properly associate dynamically inserted validation error text with the form inputs causing them. Just appending a red text div next to the input is only visual, leaving screen-reader users uninformed of validation failures.
+**Action:** Always add unique IDs to dynamic error elements, set `aria-live="polite"` on them, and tie them to their input fields via `aria-describedby` and `aria-invalid="true"`.

--- a/data/common.js
+++ b/data/common.js
@@ -395,9 +395,19 @@
             errorEl.classList.add('error-message');
             errorEl.style.color = 'red';
             errorEl.style.fontSize = '0.8em';
+            errorEl.id = inputEl.id + '-error';
+            errorEl.setAttribute('aria-live', 'polite');
             inputEl.parentElement.appendChild(errorEl);
           }
           errorEl.textContent = errorMessage;
+
+          if (errorMessage) {
+            inputEl.setAttribute('aria-invalid', 'true');
+            inputEl.setAttribute('aria-describedby', errorEl.id);
+          } else {
+            inputEl.removeAttribute('aria-invalid');
+            inputEl.removeAttribute('aria-describedby');
+          }
         }
 
         function debounce(func, timeout = 500){


### PR DESCRIPTION
💡 What: Updated `showInputError` in `data/common.js` to assign a unique ID to dynamic error messages, set `aria-live="polite"`, and link the error to the input field using `aria-describedby` and `aria-invalid="true"`.

🎯 Why: Previously, inline validation error messages were appended as unlinked red text. While sighted users could infer the relationship, screen readers could not properly announce the errors or associate them with the invalid input. This fixes that barrier.

📸 Before/After: Visuals remain identical, but accessibility tree now correctly maps validation state.

♿ Accessibility: Ensures dynamically injected inline error text is immediately announced and correctly tied to the source input field for screen reader users.

---
*PR created automatically by Jules for task [4311046175875295865](https://jules.google.com/task/4311046175875295865) started by @ManupaKDU*