### PR TITLE
🎨 Palette: Improve dynamic form validation accessibility

### DIFF
--- a/data/common.js
+++ b/data/common.js
@@ -390,14 +390,28 @@
         // Display error messages below input fields
         function showInputError(inputEl, errorMessage) {
           let errorEl = inputEl.nextElementSibling;
+          const inputId = inputEl.id || inputEl.name || ('input-' + Math.random().toString(36).substr(2, 9));
+          const errorId = inputId + '-error';
           if (!errorEl || !errorEl.classList.contains('error-message')) {
             errorEl = document.createElement('div');
             errorEl.classList.add('error-message');
             errorEl.style.color = 'red';
             errorEl.style.fontSize = '0.8em';
+            errorEl.setAttribute('aria-live', 'polite');
             inputEl.parentElement.appendChild(errorEl);
           }
-          errorEl.textContent = errorMessage;
+          // Ensure the ID is always set, even if the element already existed
+          errorEl.id = errorId;
+
+          if (errorMessage) {
+            errorEl.textContent = errorMessage;
+            inputEl.setAttribute('aria-invalid', 'true');
+            inputEl.setAttribute('aria-describedby', errorId);
+          } else {
+            errorEl.textContent = '';
+            inputEl.removeAttribute('aria-invalid');
+            inputEl.removeAttribute('aria-describedby');
+          }
         }
 
         function debounce(func, timeout = 500){


### PR DESCRIPTION
💡 What: Added dynamic ARIA attributes (`aria-live="polite"`, `aria-invalid`, `aria-describedby`) to the dynamic error messages and corresponding inputs generated by `showInputError` in `common.js`.
🎯 Why: Without these attributes, screen reader users were not notified when a form validation error occurred dynamically (e.g. invalid AP password), and when they focused the field, the error message wasn't read out.
📸 Before/After: N/A - Visual UI remains identical.
♿ Accessibility: Ensures that form errors are properly announced by screen readers. Evaluates `aria-live="polite"` for the newly created error node, assigns a unique `id` leveraging the input's `id` or `name` (or a random string fallback), and correctly toggles `aria-invalid` and `aria-describedby` when errors appear and disappear.

---
*PR created automatically by Jules for task [7115304992604590608](https://jules.google.com/task/7115304992604590608) started by @ManupaKDU*