### PR TITLE
⚡ Bolt: Optimize config file reading with in-memory parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -55,3 +55,6 @@
 ## 2024-11-20 - O(N) Performance hit via redundant strlen Calls
 **Learning:** Redundant `strlen(variable)` calls in string extraction paths (e.g., `extractQueryKeyVal` and `appSpecific.cpp`) or in `strncpy` operations are causing redundant string traversal. Instead of using pointer math or recalculating, we can remove the redundant splitting logic completely if the function has already separated them, or use a cached length/direct pointer math like `endPtr + 1`.
 **Action:** Avoid re-splitting strings that have already been separated by `extractQueryKeyVal`, and avoid calling `strlen` repeatedly on the same variable to extract the value if a pointer like `endPtr` is already available from `strchr`.
+## 2026-05-20 - File Read Return Values
+**Learning:** When performing bulk I/O with `file.read()` on ESP32, the reported `file.size()` may not exactly match the bytes read. Relying on `file.size()` to set loop bounds without capturing the return value can result in out-of-bounds reads into uninitialized memory.
+**Action:** Always capture the return value of `file.read()` (e.g. `size_t bytesRead = file.read(...)`) and use it to bound operations and set the null terminator.

--- a/prefs.cpp
+++ b/prefs.cpp
@@ -157,10 +157,30 @@ static bool loadConfigVect() {
   configs.reserve(MAX_CONFIGS);
   // extract each config line from file
   File file = STORAGE.open(CONFIG_FILE_PATH, FILE_READ);
-  while (file.available()) {
-    String configLineStr = file.readStringUntil('\n');
-    if (configLineStr.length()) loadVectItem(configLineStr.c_str());
+  if (file) {
+    size_t fsize = file.size();
+    if (fsize > 0) {
+      char* fileBuf = (char*)malloc(fsize + 1);
+      if (fileBuf) {
+        size_t bytesRead = file.read((uint8_t*)fileBuf, fsize);
+        fileBuf[bytesRead] = 0;
+        char* p = fileBuf;
+        char* end = fileBuf + bytesRead;
+        while (p < end) {
+          char* nl = strchr(p, '\n');
+          if (nl) *nl = 0;
+          if (*p) loadVectItem(p);
+          if (nl) p = nl + 1;
+          else break;
+        }
+        free(fileBuf);
+      } else {
+        LOG_WRN("Failed to allocate memory for config file reading");
+      }
+    }
+    file.close();
   }
+
   // sort vector by key (element 0 in row)
   std::sort(configs.begin(), configs.end(), [] (
     const std::vector<std::string> &a, const std::vector<std::string> &b) {
@@ -168,7 +188,6 @@ static bool loadConfigVect() {
   );
   // return malloc to default
   if (psramFound()) heap_caps_malloc_extmem_enable(MAX_RAM);
-  file.close();
   return true;
 }
 


### PR DESCRIPTION
💡 What: Refactored `loadConfigVect` in `prefs.cpp` to replace line-by-line `file.readStringUntil('\n')` calls with a single bulk read using `file.read()`, followed by in-memory parsing utilizing `strchr`.

🎯 Why: The original approach read the file char by char (or in very small chunks) and repeatedly allocated/deallocated Arduino `String` objects for every configuration line. On memory-constrained devices like the ESP32, this causes significant heap fragmentation and slows down boot time.

📊 Impact: Substantially reduces file system I/O overhead by doing a single bulk read and significantly minimizes heap fragmentation and allocation time by eliminating temporary `String` objects.

🔬 Measurement: Verify changes manually by compiling and testing the application, or by inspecting `cppcheck` outputs to ensure no regressions or memory leaks. A local mock execution confirmed the in-place split logic handles newlines identical to `readStringUntil`.

---
*PR created automatically by Jules for task [5397502730143742507](https://jules.google.com/task/5397502730143742507) started by @ManupaKDU*