### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal vulnerability

### DIFF
--- a/test_mock.cpp
+++ b/test_mock.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <cstring>
+
+bool isPathTraversal(const char* path) {
+  if (!path) return false;
+  return strstr(path, "../") || strstr(path, "..\\") ||
+         strstr(path, "/..") || strstr(path, "\\..") ||
+         !strcmp(path, "..");
+}
+
+int main() {
+    const char* test_cases[] = {
+        "valid_path.txt",
+        "folder/file.svg",
+        "../file.txt",
+        "..\\file.txt",
+        "/..",
+        "folder/../file",
+        ".."
+    };
+
+    bool expected[] = {
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true
+    };
+
+    bool all_passed = true;
+    for (int i = 0; i < 7; ++i) {
+        bool result = isPathTraversal(test_cases[i]);
+        if (result != expected[i]) {
+            std::cout << "Test failed for: " << test_cases[i] << " Expected: " << expected[i] << " Got: " << result << std::endl;
+            all_passed = false;
+        }
+    }
+
+    if (all_passed) {
+        std::cout << "All path traversal tests passed!" << std::endl;
+        return 0;
+    }
+    return 1;
+}

--- a/webServer.cpp
+++ b/webServer.cpp
@@ -237,6 +237,13 @@ static esp_err_t webHandler(httpd_req_t* req) {
     // any svg file
     httpd_resp_set_type(req, "image/svg+xml");
   } else LOG_WRN("Unknown file type %s", variable);
+
+  if (isPathTraversal(variable)) {
+    LOG_WRN("Path traversal attempt detected before formatting: %s", variable);
+    httpd_resp_send_404(req);
+    return ESP_FAIL;
+  }
+
   int dlen = snprintf(inFileName, IN_FILE_NAME_LEN - 1, "%s/%s", DATA_DIR, variable);
   if (dlen >= IN_FILE_NAME_LEN) LOG_WRN("file name truncated");
   return fileHandler(req);


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** A path traversal vulnerability existed in the static file handler within `webServer.cpp`. The user-provided `variable` could be injected into `inFileName` without being checked for traversal sequences like `../`, potentially allowing an attacker to read arbitrary files from the storage filesystem.
**🎯 Impact:** Unauthorized access to sensitive device files or configuration data.
**🛠️ Fix:** Added an explicit `isPathTraversal` validation check immediately before formatting the `variable` into the file path string (`snprintf`). This acts as an additional defense-in-depth barrier.
**✅ Verification:** Compiled static mock tests on the host to verify the traversal logic safely intercepts variations of dot-dot-slash paths while permitting legitimate file names. Ran static analysis (`cppcheck`) to ensure no new errors were introduced.

---
*PR created automatically by Jules for task [3355637429291848021](https://jules.google.com/task/3355637429291848021) started by @ManupaKDU*