### PR TITLE
🎨 Palette: Add focus-visible states for span buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,6 @@
 ## 2025-02-12 - File Transfer Button Disabled States
 **Learning:** In the MJPEG2SD interface, file transfer action buttons (Download, Upload, Delete) were previously left enabled even when no file was selected, leading to potential confusion or invalid actions. Furthermore, "Download" applies only to files (not folders).
 **Action:** Added default `disabled` attributes/classes to the HTML and hooked into the existing `selectFileOrFolder` JS function to dynamically toggle these states. When writing Playwright tests to verify this dynamic UI logic, elements inside inactive tabs (like `.tabcontent`) must be explicitly forced to `display: block` via JS evaluation before interaction, otherwise Playwright fails to compute their styles or interact with their children.
+## 2026-05-24 - Focus States for Span Buttons
+**Learning:** Custom UI elements like `span` with `role="button"` require explicit CSS `:focus-visible` definitions to show focus rings. Unlike native `<button>` elements, they don't get browser default focus styles automatically even with `tabindex="0"`.
+**Action:** When adding or reviewing custom interactive components in ESP32 HTML templates (`MJPEG2SD.htm`, `Auxil.htm`), explicitly add them (e.g., `span[role="button"]:focus-visible`) to the global keyboard focus outline rules.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -215,7 +215,7 @@
        background: var(--buttonActive);
       }
 
-      button:focus-visible, div[role="button"]:focus-visible, nav[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+      button:focus-visible, div[role="button"]:focus-visible, nav[role="button"]:focus-visible, span[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -219,7 +219,7 @@
        background: var(--buttonActive);
       }
 
-      button:focus-visible, div[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+      button:focus-visible, div[role="button"]:focus-visible, span[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }


### PR DESCRIPTION
💡 What: Added `span[role="button"]:focus-visible` to the global keyboard focus outline CSS rules in `data/MJPEG2SD.htm` and `data/Auxil.htm`.

🎯 Why: Custom elements (like `span` or `div`) configured as buttons using `role="button"` and `tabindex="0"` do not automatically receive default browser focus rings. While `div` elements were styled, `span` elements (such as the dynamically generated `.removeButton` in the Camera Hub) were missing, making keyboard navigation difficult.

📸 Before/After: Visual outline (white ring) now successfully applies to `span` elements acting as buttons when focused via keyboard navigation.

♿ Accessibility: Ensures keyboard users have clear visual feedback when tabbing to interactive `span` elements, complying with standard web accessibility guidelines.

---
*PR created automatically by Jules for task [15221836660075475899](https://jules.google.com/task/15221836660075475899) started by @ManupaKDU*