### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in WebDAV

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -98,3 +98,8 @@
 **Vulnerability:** Path traversal possible by passing `../` in the `variable` parameter of `webServer.cpp`, bypassing intended directory scope after `snprintf` formatting.
 **Learning:** Checking for traversal *before* formatting might not be enough or was omitted at the specific usage site where `variable` was processed for static file responses. The requested fix specifically required a `strstr(variable, "../")` check after formatting.
 **Prevention:** Ensure explicit bounds and traversal checks (`strstr(..., "../")` or robust alternatives) are placed immediately before accessing files based on user-provided path segments.
+
+## 2024-05-18 - [WebDAV parsing Buffer Overflows]
+**Vulnerability:** Static buffer overflows in `webDav.cpp` where unbounded network input (like `req->uri`) or max-length variables were copied into small stack/BSS buffers via `sprintf`.
+**Learning:** `sprintf` with uncontrolled strings on the ESP32 can write into adjacent variables, causing memory corruption and remote crash/RCE potential. This is a common pattern in older C-style ESP strings.
+**Prevention:** Always use `snprintf` explicitly bound to the `sizeof()` the destination buffer instead of relying on `sprintf`, especially for HTTP request properties.

--- a/webDav.cpp
+++ b/webDav.cpp
@@ -81,7 +81,7 @@ static bool isFolder() {
 static void sendContentProp(const char* prop, const char* value) {
   // set individual XML properties in response
   char propStr[strlen(prop) * 2 + strlen(value) + 15];
-  sprintf(propStr, "<D:%s>%s</D:%s>", prop, value, prop);
+  snprintf(propStr, sizeof(propStr), "<D:%s>%s</D:%s>", prop, value, prop);
   httpd_resp_sendstr_chunk(req, propStr);
   LOG_VRB("propStr %s", propStr);
 }
@@ -102,7 +102,7 @@ static void sendPropResponse(File& file, const char* payload) {
   if (file.isDirectory()) sendContentProp("resourcetype", "<D:collection/>");
   else {
     char fsizeStr[15];
-    sprintf(fsizeStr, "%u", file.size());
+    snprintf(fsizeStr, sizeof(fsizeStr), "%u", file.size());
     sendContentProp("getcontentlength", fsizeStr);
     sendContentProp("getcontenttype", mimeTypes[getMimeType(file.path())]);
     httpd_resp_sendstr_chunk(req, "<resourcetype/>");
@@ -112,10 +112,10 @@ static void sendPropResponse(File& file, const char* payload) {
   if (strlen(payload)) {
     // return quota data if requested
     if (strstr(payload, "quota-available-bytes") != NULL || strstr(payload, "quota-used-bytes") != NULL) {
-      char numberStr[15];
-      sprintf(numberStr, "%llu", (uint64_t)STORAGE.totalBytes() - (uint64_t)STORAGE.usedBytes());
+      char numberStr[24];
+      snprintf(numberStr, sizeof(numberStr), "%llu", (uint64_t)STORAGE.totalBytes() - (uint64_t)STORAGE.usedBytes());
       sendContentProp("quota-available-bytes", numberStr);
-      sprintf(numberStr, "%llu", (uint64_t)STORAGE.usedBytes());
+      snprintf(numberStr, sizeof(numberStr), "%llu", (uint64_t)STORAGE.usedBytes());
       sendContentProp("quota-used-bytes", numberStr);
     }
   }
@@ -213,7 +213,7 @@ static bool handleLock() {
   const char* lockToken = "0123456789012345";
   httpd_resp_set_hdr(req, "Lock-Token", lockToken);
   char resp[strlen(XML5) + strlen(lockToken) + strlen(XML6) + 1];
-  sprintf(resp, "%s%s%s", XML5, lockToken, XML6);
+  snprintf(resp, sizeof(resp), "%s%s%s", XML5, lockToken, XML6);
   httpd_resp_set_type(req, "application/xml;charset=utf-8");
   httpd_resp_sendstr(req, resp);
   return true;
@@ -318,7 +318,7 @@ static bool handleCopy() {
 bool handleWebDav(httpd_req_t* rreq) {
   // extract method to determine which WebDAV action to take
   req = rreq;
-  sprintf(pathName, "%s", req->uri + strlen(WEBDAV)); // strip out "/webdav"
+  snprintf(pathName, sizeof(pathName), "%s", req->uri + strlen(WEBDAV)); // strip out "/webdav"
   if (pathName[strlen(pathName) - 1] == '/') pathName[strlen(pathName) - 1] = 0; // remove final / if present
   if (!strlen(pathName)) strcpy(pathName, "/"); // if pathname empty, use single /
   urlDecode(pathName);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsafe C-style string manipulation (`sprintf`) was used throughout `webDav.cpp`. In particular, HTTP URIs and potentially very large 64-bit file sizes (`%llu`) were copied into small static stack arrays (e.g., a 15-byte array for a 20-digit max integer), posing a significant buffer overflow risk that could overwrite adjacent memory stack structures leading to crashes or RCE. 
🎯 **Impact:** Exploitation of the `req->uri` parsing could lead to remote crashes or arbitrary code execution by overflowing `pathName` when long URIs are supplied.
🛠️ **Fix:** Replaced all instances of `sprintf` with `snprintf` specifying destination buffer sizes. Increased `numberStr` array size from 15 bytes to 24 bytes to safely hold 64-bit strings.
✅ **Verification:** Verified compilation via `cppcheck`. Ran an isolated C++ mock test dynamically passing >200 byte URIs and `UINT64_MAX` to verify they safely truncate without crashing, and ran the existing string/url test suites to ensure no regressions. Logged to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6600061994424775329](https://jules.google.com/task/6600061994424775329) started by @ManupaKDU*