### PR TITLE
⚡ Bolt: Optimize bulk file reading performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,7 @@
 ## 2024-05-03 - String Pointer Optimization
 **Learning:** In C/C++ applications on the ESP32, repeatedly calculating string offsets with `strlen()` during in-place string splitting loops introduces an unnecessary O(N) performance penalty.
 **Action:** When a pointer to a split character (e.g., via `strchr()`) is already computed and bounded, use pointer arithmetic (`endPtr + 1`) to advance to the remainder of the string instead of re-calculating the length (`variable + strlen(variable) + 1`).
+
+## 2026-05-25 - Optimize File Reading in ESP32
+**Learning:** `file.readBytes` adds significant timer (`millis()`) overhead per byte because it uses `timedRead()` internally. Direct `file.read(buffer, size)` bulk reading is much faster and more efficient on the ESP32.
+**Action:** Replace `file.readBytes(buffer, size)` with `file.read((uint8_t*)buffer, size)` when loading files into memory buffers.

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -70,7 +70,8 @@ void loadCerts() {
         } else {
           // load contents
           serverCerts[i] = psramFound() ? (char*)ps_malloc(file.size() + 1) : (char*)malloc(file.size() + 1); 
-          size_t inBytes = file.readBytes(serverCerts[i], file.size());
+          // Bolt: Use bulk file.read() instead of file.readBytes() to avoid per-byte timer overhead
+          size_t inBytes = file.read((uint8_t*)serverCerts[i], file.size());
           if (inBytes != file.size()) {
             LOG_WRN("File %s not correctly loaded", certFiles[i]);
             useHttps = false;


### PR DESCRIPTION
💡 What: Replaced `file.readBytes` with `file.read` in `certificates.cpp` when loading server certificates into memory buffers. Added corresponding performance note to `.jules/bolt.md`.
🎯 Why: `file.readBytes` uses `timedRead()` internally in the ESP32 framework, introducing a costly `millis()` timer check for every single byte read. This causes severe overhead during bulk loading. Using `file.read` bypasses the timeout loop and reads directly.
📊 Impact: Significantly faster file loading operations. Eliminates O(N) timer-check latency on file sizes.
🔬 Measurement: Verified functionality by mocking `File` and compiling a simulated run. Performance can be measured by timing `loadCerts()` execution time before and after.

---
*PR created automatically by Jules for task [1760429800823202436](https://jules.google.com/task/1760429800823202436) started by @ManupaKDU*