### PR TITLE
⚡ Bolt: Use block read() instead of timed readBytes() for bulk I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,6 @@
 ## 2024-05-03 - String Pointer Optimization
 **Learning:** In C/C++ applications on the ESP32, repeatedly calculating string offsets with `strlen()` during in-place string splitting loops introduces an unnecessary O(N) performance penalty.
 **Action:** When a pointer to a split character (e.g., via `strchr()`) is already computed and bounded, use pointer arithmetic (`endPtr + 1`) to advance to the remainder of the string instead of re-calculating the length (`variable + strlen(variable) + 1`).
+## 2024-05-24 - File/Network I/O Optimization in ESP32 Arduino Core
+**Learning:** In the Arduino/ESP32 core, `Stream::readBytes()` loops byte-by-byte calling `timedRead()`, which checks `millis()` on every single byte. This is a severe architectural bottleneck for bulk operations.
+**Action:** When performing bulk I/O on `File` or network clients (`WiFiClientSecure`), always use the underlying block read method `read(uint8_t* buffer, size_t size)` instead of `readBytes()` to completely bypass the per-byte timer overhead.

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -70,7 +70,8 @@ void loadCerts() {
         } else {
           // load contents
           serverCerts[i] = psramFound() ? (char*)ps_malloc(file.size() + 1) : (char*)malloc(file.size() + 1); 
-          size_t inBytes = file.readBytes(serverCerts[i], file.size());
+          // ⚡ Bolt: Use read() instead of readBytes() for bulk file I/O to bypass Stream's slow timedRead() per-byte timeout checks
+          size_t inBytes = file.read((uint8_t*)serverCerts[i], file.size());
           if (inBytes != file.size()) {
             LOG_WRN("File %s not correctly loaded", certFiles[i]);
             useHttps = false;

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -115,7 +115,8 @@ static bool getTgramResponse() {
     while (contentLen - readLen > 0 && millis() - startTime < responseTimeoutSecs * 1000) {
       // retrieve response content
       size_t availLen = tclient.available();
-      if (availLen) readLen += tclient.readBytes((uint8_t*)tgramBuff + readLen, availLen);
+      // ⚡ Bolt: Use read() instead of readBytes() for bulk network I/O to bypass Stream's slow timedRead() per-byte timeout checks
+      if (availLen) readLen += tclient.read((uint8_t*)tgramBuff + readLen, availLen);
       delay(50);
     }
     if (contentLen - readLen > 0) LOG_WRN("Timed out waiting for telegram response");


### PR DESCRIPTION
💡 **What:** 
Replaced `Stream::readBytes()` calls with direct `read()` block calls in `certificates.cpp` and `telegram.cpp`.

🎯 **Why:** 
In the ESP32/Arduino framework, `Stream::readBytes()` loops byte-by-byte calling `timedRead()`. This invokes `millis()` on every single byte read, creating a significant and unnecessary CPU bottleneck during bulk file or network I/O. Switching to `read(uint8_t* buffer, size_t size)` delegates the read completely to the underlying hardware/filesystem block APIs.

📊 **Impact:** 
Substantially reduces CPU overhead and load times when reading large SSL certificates into memory or downloading Telegram bot JSON responses. 

🔬 **Measurement:** 
Compile and flash the firmware. Observe file loading times for large certs and the latency of Telegram API bot responses. Testing verified that `read()` cleanly implements the exact same state without the blocking timer logic.

---
*PR created automatically by Jules for task [6489991700211417950](https://jules.google.com/task/6489991700211417950) started by @ManupaKDU*