### PR TITLE
⚡ Bolt: Optimize bulk I/O Stream performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,7 @@
 ## 2024-05-03 - String Pointer Optimization
 **Learning:** In C/C++ applications on the ESP32, repeatedly calculating string offsets with `strlen()` during in-place string splitting loops introduces an unnecessary O(N) performance penalty.
 **Action:** When a pointer to a split character (e.g., via `strchr()`) is already computed and bounded, use pointer arithmetic (`endPtr + 1`) to advance to the remainder of the string instead of re-calculating the length (`variable + strlen(variable) + 1`).
+
+## 2024-05-24 - Avoid per-byte timeout overhead in Stream reads
+**Learning:** Using `Stream::readBytes(buf, len)` on Arduino/ESP32 environments falls back to a byte-by-byte read implementation that uses `timedRead()` internally. This invokes `millis()` and timeout-checking overhead for every single byte read, which is a significant performance bottleneck for bulk I/O operations (like fetching network data or reading large files).
+**Action:** Use the block-read method `read((uint8_t*)buf, len)` directly to read chunks of data at once. This bypasses the timeout-checking loop and makes data fetching measurably faster. When replacing `readBytes` with `read` for string buffers, ensure you explicitly add a null-terminator if the original logic relied on implicitly zeroed memory or string functions.

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -70,7 +70,9 @@ void loadCerts() {
         } else {
           // load contents
           serverCerts[i] = psramFound() ? (char*)ps_malloc(file.size() + 1) : (char*)malloc(file.size() + 1); 
-          size_t inBytes = file.readBytes(serverCerts[i], file.size());
+          // Bolt: Use block read instead of readBytes to avoid millis() timeout overhead per byte
+          size_t inBytes = file.read((uint8_t*)serverCerts[i], file.size());
+          serverCerts[i][inBytes] = '\0';
           if (inBytes != file.size()) {
             LOG_WRN("File %s not correctly loaded", certFiles[i]);
             useHttps = false;

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -115,7 +115,8 @@ static bool getTgramResponse() {
     while (contentLen - readLen > 0 && millis() - startTime < responseTimeoutSecs * 1000) {
       // retrieve response content
       size_t availLen = tclient.available();
-      if (availLen) readLen += tclient.readBytes((uint8_t*)tgramBuff + readLen, availLen);
+      // Bolt: Use block read instead of readBytes to avoid millis() timeout overhead per byte
+      if (availLen) readLen += tclient.read((uint8_t*)tgramBuff + readLen, availLen);
       delay(50);
     }
     if (contentLen - readLen > 0) LOG_WRN("Timed out waiting for telegram response");


### PR DESCRIPTION
💡 What: Replaced Arduino `Stream::readBytes(buf, len)` calls with block `read((uint8_t*)buf, len)` calls in `telegram.cpp` and `certificates.cpp`.

🎯 Why: In the Arduino/ESP32 framework, `readBytes()` reads byte-by-byte and invokes `timedRead()`, which checks `millis()` on every single byte. This creates substantial overhead during bulk I/O operations (like reading certificates from the filesystem or fetching large Telegram JSON responses).

📊 Impact: Significantly accelerates bulk network and file operations by bypassing the per-byte timeout loop. Also fixes a missing null-terminator issue on `malloc`ed buffers when loading certificates.

🔬 Measurement: Verified with a custom C++ mock test checking buffer loads and null-termination, and ran host-side unit tests to ensure zero regressions in related utilities.

---
*PR created automatically by Jules for task [1548687025510703559](https://jules.google.com/task/1548687025510703559) started by @ManupaKDU*