### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in appSpecificWebHandler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -98,3 +98,8 @@
 **Vulnerability:** Path traversal possible by passing `../` in the `variable` parameter of `webServer.cpp`, bypassing intended directory scope after `snprintf` formatting.
 **Learning:** Checking for traversal *before* formatting might not be enough or was omitted at the specific usage site where `variable` was processed for static file responses. The requested fix specifically required a `strstr(variable, "../")` check after formatting.
 **Prevention:** Ensure explicit bounds and traversal checks (`strstr(..., "../")` or robust alternatives) are placed immediately before accessing files based on user-provided path segments.
+
+## 2024-06-25 - [CRITICAL] Unbounded strcpy Buffer Overflow in appSpecificWebHandler
+**Vulnerability:** A critical buffer overflow risk was identified in `appSpecificWebHandler` (`appSpecific.cpp`), where `strcpy(inFileName, value);` was used to copy URL parameter values directly into a statically sized `inFileName` array (`IN_FILE_NAME_LEN`). Because `value` comes from untrusted HTTP queries, it could easily exceed the array bounds.
+**Learning:** Functions that parse untrusted input from HTTP queries or WebSocket payloads into fixed-size buffers must always use bounded copying operations like `strncpy` or `snprintf`.
+**Prevention:** Always use bounds checking when extracting input: `strncpy(dest, src, size - 1)` followed by explicit null termination `dest[size - 1] = 0`.

--- a/appSpecific.cpp
+++ b/appSpecific.cpp
@@ -316,7 +316,8 @@ esp_err_t appSpecificWebHandler(httpd_req_t *req, const char* variable, const ch
   // update handling requiring response specific to mjpeg2sd
   if (!strcmp(variable, "sfile")) {
     // get folders / files on SD, save received filename if has required extension
-    strcpy(inFileName, value);
+    strncpy(inFileName, value, IN_FILE_NAME_LEN - 1);
+    inFileName[IN_FILE_NAME_LEN - 1] = 0;
     if (!forceRecord) doPlayback = listDir(inFileName, jsonBuff, JSON_BUFF_LEN, AVI_EXT); // browser control
     else strcpy(jsonBuff, "{}");
     httpd_resp_set_type(req, "application/json");
@@ -787,8 +788,7 @@ void appSpecificTelegramTask(void* p) {
         deleteFolderOrFile(ramLogName);
       } else if (!strcmp(userCmd, "/extIP")) {
         char extIpPt[24];
-        strcpy(extIpPt, extIP);
-        if (strlen(portFwd)) strcat(extIpPt, portFwd);
+        snprintf(extIpPt, sizeof(extIpPt), "%s%s", extIP, strlen(portFwd) ? portFwd : "");
         sendTgramMessage("Ext IP: ", extIpPt, "");
       } else {
         // initially assume it is an avi file download request


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in appSpecificWebHandler

🚨 Severity: CRITICAL
💡 Vulnerability: The `appSpecificWebHandler` used `strcpy(inFileName, value);` to copy untrusted HTTP query parameters directly into a statically sized `inFileName` array. A secondary minor issue existed when appending `portFwd` to `extIpPt`.
🎯 Impact: An attacker sending an overly long URL parameter could overwrite stack memory, causing an application crash (DoS) or potentially leading to arbitrary code execution.
🛠️ Fix: Replaced `strcpy` with bounds-safe `strncpy(inFileName, value, IN_FILE_NAME_LEN - 1)` and explicit null termination. Replaced `extIpPt` concatenation with `snprintf`.
✅ Verification: Created a mock C++ test to ensure that long strings are safely truncated without exceeding buffer boundaries or causing memory corruption.

---
*PR created automatically by Jules for task [7568053675063216386](https://jules.google.com/task/7568053675063216386) started by @ManupaKDU*