### PR TITLE
⚡ Bolt: Replace readBytes with read for block I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,7 @@
 ## 2024-05-03 - String Pointer Optimization
 **Learning:** In C/C++ applications on the ESP32, repeatedly calculating string offsets with `strlen()` during in-place string splitting loops introduces an unnecessary O(N) performance penalty.
 **Action:** When a pointer to a split character (e.g., via `strchr()`) is already computed and bounded, use pointer arithmetic (`endPtr + 1`) to advance to the remainder of the string instead of re-calculating the length (`variable + strlen(variable) + 1`).
+
+## 2024-05-29 - Block reads bypass timedRead overhead
+**Learning:** In the ESP32/Arduino framework, `Stream::readBytes()` (used by `File` and `WiFiClientSecure`) incurs significant performance overhead due to per-byte timeout checks (`millis()` via `timedRead()`). This is essentially an O(N) overhead layer around what could be a block read.
+**Action:** When loading data into memory buffers where the size is known or we want to read everything available, prefer block reading via `read(uint8_t* buf, size_t size)` over `readBytes()` to bypass this timer overhead and drastically improve bulk I/O performance.

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -70,7 +70,8 @@ void loadCerts() {
         } else {
           // load contents
           serverCerts[i] = psramFound() ? (char*)ps_malloc(file.size() + 1) : (char*)malloc(file.size() + 1); 
-          size_t inBytes = file.readBytes(serverCerts[i], file.size());
+          // ⚡ Bolt optimization: Use block read() instead of readBytes() to bypass per-byte timedRead() overhead
+          size_t inBytes = file.read((uint8_t*)serverCerts[i], file.size());
           if (inBytes != file.size()) {
             LOG_WRN("File %s not correctly loaded", certFiles[i]);
             useHttps = false;

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -115,7 +115,8 @@ static bool getTgramResponse() {
     while (contentLen - readLen > 0 && millis() - startTime < responseTimeoutSecs * 1000) {
       // retrieve response content
       size_t availLen = tclient.available();
-      if (availLen) readLen += tclient.readBytes((uint8_t*)tgramBuff + readLen, availLen);
+      // ⚡ Bolt optimization: Use block read() instead of readBytes() to bypass per-byte timedRead() overhead
+      if (availLen) readLen += tclient.read((uint8_t*)tgramBuff + readLen, availLen);
       delay(50);
     }
     if (contentLen - readLen > 0) LOG_WRN("Timed out waiting for telegram response");


### PR DESCRIPTION
💡 What: Replaced byte-by-byte `readBytes()` calls with block `read(uint8_t*, size_t)` in `certificates.cpp` and `telegram.cpp`.
🎯 Why: `Stream::readBytes()` incurs significant performance overhead on ESP32 because it internally loops over `timedRead()` for every single byte. Block reading delegates the I/O directly to the underlying filesystem or network buffer.
📊 Impact: Eliminates N virtual function calls and N timer checks (where N is file or chunk size), significantly accelerating certificate loading and telegram buffer reading.
🔬 Measurement: Verify that HTTPS functionality (loading certs) and Telegram integration function correctly without regression. Code execution of these paths will be measurably faster.

---
*PR created automatically by Jules for task [15603776013481531171](https://jules.google.com/task/15603776013481531171) started by @ManupaKDU*