### PR TITLE
🎨 Palette: Add focus-visible styling to span buttons for keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,7 @@
 ## 2025-02-12 - File Transfer Button Disabled States
 **Learning:** In the MJPEG2SD interface, file transfer action buttons (Download, Upload, Delete) were previously left enabled even when no file was selected, leading to potential confusion or invalid actions. Furthermore, "Download" applies only to files (not folders).
 **Action:** Added default `disabled` attributes/classes to the HTML and hooked into the existing `selectFileOrFolder` JS function to dynamically toggle these states. When writing Playwright tests to verify this dynamic UI logic, elements inside inactive tabs (like `.tabcontent`) must be explicitly forced to `display: block` via JS evaluation before interaction, otherwise Playwright fails to compute their styles or interact with their children.
+## 2026-05-29 - Span focus styles
+
+**Learning:** When building custom interactive components with `span[role="button"]` in this app's vanilla CSS setup, they do not inherit default browser focus rings (like `<button>` or `<input>` elements do). The CSS only explicitly handled `div[role="button"]:focus-visible` or `button:focus-visible`. If a new inline component uses `span`, keyboard focus becomes invisible.
+**Action:** When creating inline, custom interactive components with `role="button"`, explicitly include `span[role="button"]` in the global `:focus-visible` CSS definitions to ensure keyboard navigation remains accessible.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -171,10 +171,10 @@
         fill: var(--buttonActive);
         outline: none; /* Remove focus outline if not needed */
       }
-      div[role="button"]:focus {
+      div[role="button"]:focus, span[role="button"]:focus {
         outline: none;
       }
-      div[role="button"] {
+      div[role="button"], span[role="button"] {
         cursor: pointer;
       }
 
@@ -215,7 +215,7 @@
        background: var(--buttonActive);
       }
 
-      button:focus-visible, div[role="button"]:focus-visible, nav[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+      button:focus-visible, div[role="button"]:focus-visible, nav[role="button"]:focus-visible, span[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -171,13 +171,13 @@
         fill: var(--buttonActive);
         outline: none; /* Remove focus outline if not needed */
       }
-      div[role="button"]:focus {
+      div[role="button"]:focus, span[role="button"]:focus {
         outline: none;
       }
-      div[role="button"] {
+      div[role="button"], span[role="button"] {
         cursor: pointer;
       }
-      div[role="button"]:focus-visible, nav[role="button"]:focus-visible {
+      div[role="button"]:focus-visible, nav[role="button"]:focus-visible, span[role="button"]:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }
@@ -219,7 +219,7 @@
        background: var(--buttonActive);
       }
 
-      button:focus-visible, div[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+      button:focus-visible, div[role="button"]:focus-visible, span[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }


### PR DESCRIPTION
💡 What: Added `span[role="button"]` to the global `:focus-visible` CSS rules in `MJPEG2SD.htm` and `Auxil.htm` alongside existing elements like `button` and `div[role="button"]`.
🎯 Why: In this app, inline dynamically generated UI components utilizing `span[role="button"]` (such as the IP address remove buttons) fail to inherit default browser focus rings. By omitting them from the explicit CSS overrides, they remained entirely invisible to keyboard-only navigation users, breaking accessibility.
📸 Before/After: Before, a focused remove button showed no focus ring. After, it shows a solid green 2px outline.
♿ Accessibility: Ensures full keyboard navigability for custom inline interactive elements by providing clear, standardized visual feedback on focus.

---
*PR created automatically by Jules for task [16455768678729864458](https://jules.google.com/task/16455768678729864458) started by @ManupaKDU*