### PR TITLE
⚡ Bolt: Bypass Stream::readBytes timeout overhead with block reads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,6 @@
 ## 2024-05-03 - String Pointer Optimization
 **Learning:** In C/C++ applications on the ESP32, repeatedly calculating string offsets with `strlen()` during in-place string splitting loops introduces an unnecessary O(N) performance penalty.
 **Action:** When a pointer to a split character (e.g., via `strchr()`) is already computed and bounded, use pointer arithmetic (`endPtr + 1`) to advance to the remainder of the string instead of re-calculating the length (`variable + strlen(variable) + 1`).
+## 2024-05-31 - Bypass Stream::readBytes timeout overhead with block reads
+**Learning:** In the Arduino/ESP32 framework, `Stream::readBytes()` is typically implemented as a byte-by-byte loop that evaluates `millis()` to check for timeouts on every single byte. When loading large amounts of data (e.g., certificates from the filesystem, audio buffers from I2S, or TLS responses), this creates massive CPU overhead.
+**Action:** Replace `Stream::readBytes(buf, len)` with the underlying block read methods `read((uint8_t*)buf, len)` inherited by subclasses like `File`, `Client`, or `I2SClass`. Ensure that you properly check return types, as network `Client` implementations return an `int` which can be `-1` on error.

--- a/audio.cpp
+++ b/audio.cpp
@@ -179,7 +179,8 @@ static size_t espMicInput() {
   // read esp mic
   size_t bytesRead = 0;
   if (micUse) {
-    bytesRead = I2Smic ? I2Sstd.readBytes((char*)sampleBuffer, sampleBytes) : I2Spdm.readBytes((char*)sampleBuffer, sampleBytes);
+    // Use block read() instead of readBytes() to bypass per-byte millis() timeout overhead in Stream
+    bytesRead = I2Smic ? I2Sstd.read((uint8_t*)sampleBuffer, sampleBytes) : I2Spdm.read((uint8_t*)sampleBuffer, sampleBytes);
     applyMicGain(bytesRead);
   }
   return bytesRead;

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -70,7 +70,9 @@ void loadCerts() {
         } else {
           // load contents
           serverCerts[i] = psramFound() ? (char*)ps_malloc(file.size() + 1) : (char*)malloc(file.size() + 1); 
-          size_t inBytes = file.readBytes(serverCerts[i], file.size());
+          // Use block read() instead of readBytes() to bypass per-byte millis() timeout overhead in Stream
+          size_t inBytes = file.read((uint8_t*)serverCerts[i], file.size());
+          serverCerts[i][inBytes] = 0; // Ensure null termination
           if (inBytes != file.size()) {
             LOG_WRN("File %s not correctly loaded", certFiles[i]);
             useHttps = false;

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -115,7 +115,11 @@ static bool getTgramResponse() {
     while (contentLen - readLen > 0 && millis() - startTime < responseTimeoutSecs * 1000) {
       // retrieve response content
       size_t availLen = tclient.available();
-      if (availLen) readLen += tclient.readBytes((uint8_t*)tgramBuff + readLen, availLen);
+      // Use block read() instead of readBytes() to bypass per-byte millis() timeout overhead in Stream
+      if (availLen) {
+        int bytesRead = tclient.read((uint8_t*)tgramBuff + readLen, availLen);
+        if (bytesRead > 0) readLen += bytesRead;
+      }
       delay(50);
     }
     if (contentLen - readLen > 0) LOG_WRN("Timed out waiting for telegram response");


### PR DESCRIPTION
💡 What: Replaced inherited `Stream::readBytes()` calls with underlying block `read()` methods in `certificates.cpp`, `audio.cpp`, and `telegram.cpp`.
🎯 Why: `Stream::readBytes()` in the ESP32 Arduino framework defaults to reading data byte-by-byte while evaluating `millis()` for timeout checks on every single byte. This creates immense CPU overhead during bulk transfers.
📊 Impact: Significantly faster load times for TLS certificates, lower latency processing for ESP32 I2S audio streams, and faster Telegram response processing due to bypassing timeout calculation overhead per byte.
🔬 Measurement: Execute test stringUtils to ensure no basic syntax/regression failures, and use a network profiling tool or measure `ESP.getFreeHeap()` / cycle counts across heavy TLS or I2S loads.

---
*PR created automatically by Jules for task [587913002165681813](https://jules.google.com/task/587913002165681813) started by @ManupaKDU*