### PR TITLE
⚡ Bolt: Replace Stream::readBytes() with read() to improve bulk I/O performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,6 @@
 ## 2024-05-03 - String Pointer Optimization
 **Learning:** In C/C++ applications on the ESP32, repeatedly calculating string offsets with `strlen()` during in-place string splitting loops introduces an unnecessary O(N) performance penalty.
 **Action:** When a pointer to a split character (e.g., via `strchr()`) is already computed and bounded, use pointer arithmetic (`endPtr + 1`) to advance to the remainder of the string instead of re-calculating the length (`variable + strlen(variable) + 1`).
+## 2025-06-01 - Replace Stream::readBytes() with read()
+**Learning:** In the ESP32/Arduino framework, `Stream::readBytes()` incurs significant performance overhead due to per-byte timeout checks (`millis()` via `timedRead()`). When loading data into memory buffers, prefer block reading via `read(uint8_t* buf, size_t size)` to bypass this timer overhead and improve bulk I/O performance.
+**Action:** Always prefer `read(uint8_t*, size_t)` over `readBytes()` when reading data blocks into memory buffers for streams like `File`, `NetworkClientSecure`, and `I2SClass`.

--- a/audio.cpp
+++ b/audio.cpp
@@ -179,7 +179,8 @@ static size_t espMicInput() {
   // read esp mic
   size_t bytesRead = 0;
   if (micUse) {
-    bytesRead = I2Smic ? I2Sstd.readBytes((char*)sampleBuffer, sampleBytes) : I2Spdm.readBytes((char*)sampleBuffer, sampleBytes);
+    // ⚡ Bolt: Use read() instead of readBytes() for bulk reads to bypass per-byte timer overhead
+    bytesRead = I2Smic ? I2Sstd.read((uint8_t*)sampleBuffer, sampleBytes) : I2Spdm.read((uint8_t*)sampleBuffer, sampleBytes);
     applyMicGain(bytesRead);
   }
   return bytesRead;

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -70,7 +70,8 @@ void loadCerts() {
         } else {
           // load contents
           serverCerts[i] = psramFound() ? (char*)ps_malloc(file.size() + 1) : (char*)malloc(file.size() + 1); 
-          size_t inBytes = file.readBytes(serverCerts[i], file.size());
+          // ⚡ Bolt: Use read() instead of readBytes() for bulk reads to bypass per-byte timer overhead
+          size_t inBytes = file.read((uint8_t*)serverCerts[i], file.size());
           if (inBytes != file.size()) {
             LOG_WRN("File %s not correctly loaded", certFiles[i]);
             useHttps = false;

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -115,7 +115,8 @@ static bool getTgramResponse() {
     while (contentLen - readLen > 0 && millis() - startTime < responseTimeoutSecs * 1000) {
       // retrieve response content
       size_t availLen = tclient.available();
-      if (availLen) readLen += tclient.readBytes((uint8_t*)tgramBuff + readLen, availLen);
+      // ⚡ Bolt: Use read() instead of readBytes() for bulk reads to bypass per-byte timer overhead
+      if (availLen) readLen += tclient.read((uint8_t*)tgramBuff + readLen, availLen);
       delay(50);
     }
     if (contentLen - readLen > 0) LOG_WRN("Timed out waiting for telegram response");


### PR DESCRIPTION
💡 What: Replaced instances of `Stream::readBytes()` with `read(uint8_t*, size_t)` in `audio.cpp`, `certificates.cpp`, and `telegram.cpp`.

🎯 Why: In the ESP32/Arduino framework, `Stream::readBytes()` incurs significant performance overhead due to per-byte timeout checks (`millis()` via `timedRead()`). This slows down bulk I/O operations when loading files, audio streams, and network responses. Using `read` bypasses this timer overhead, performing direct memory bulk loading from drivers.

📊 Impact: Expected significant performance improvement (faster load times) when reading certificates, retrieving Telegram network responses, and loading audio from the I2S microphone array, saving O(N) `millis()` function calls.

🔬 Measurement: Verify the system compiles correctly. Perform functional testing by observing that network endpoints (Telegram), Audio streaming, and loading Certificates all succeed properly. No regression is expected since `read` functions exactly the same structurally as `readBytes` for these Stream types but takes a `uint8_t*` buffer.

---
*PR created automatically by Jules for task [3681299115482448837](https://jules.google.com/task/3681299115482448837) started by @ManupaKDU*