### PR TITLE
🎨 Palette: Generalize custom button CSS selectors for consistent focus styling

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,7 @@
 ## 2025-02-12 - File Transfer Button Disabled States
 **Learning:** In the MJPEG2SD interface, file transfer action buttons (Download, Upload, Delete) were previously left enabled even when no file was selected, leading to potential confusion or invalid actions. Furthermore, "Download" applies only to files (not folders).
 **Action:** Added default `disabled` attributes/classes to the HTML and hooked into the existing `selectFileOrFolder` JS function to dynamically toggle these states. When writing Playwright tests to verify this dynamic UI logic, elements inside inactive tabs (like `.tabcontent`) must be explicitly forced to `display: block` via JS evaluation before interaction, otherwise Playwright fails to compute their styles or interact with their children.
+
+## 2024-05-24 - Generalized Accessibility Selectors for Custom Buttons
+**Learning:** Using element-specific CSS selectors like `div[role="button"]` for focus and cursor styling causes dynamic UI components (like `span.removeButton`) to miss critical accessibility feedback (focus rings, pointer cursor).
+**Action:** Always prefer the generic `[role="button"]` attribute selector in stylesheets to ensure any element acting as a custom button automatically receives the correct interaction and focus styles, regardless of its underlying HTML tag.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -167,14 +167,14 @@
         ry: 15%;
       }
 
-      .buttonRect:focus, div[role="button"]:focus .buttonRect {
+      .buttonRect:focus, [role="button"]:focus .buttonRect {
         fill: var(--buttonActive);
         outline: none; /* Remove focus outline if not needed */
       }
-      div[role="button"]:focus {
+      [role="button"]:focus {
         outline: none;
       }
-      div[role="button"] {
+      [role="button"] {
         cursor: pointer;
       }
 
@@ -215,7 +215,7 @@
        background: var(--buttonActive);
       }
 
-      button:focus-visible, div[role="button"]:focus-visible, nav[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+      button:focus-visible, [role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -167,19 +167,15 @@
         ry: 15%;
       }
 
-      .buttonRect:focus, div[role="button"]:focus .buttonRect {
+      .buttonRect:focus, [role="button"]:focus .buttonRect {
         fill: var(--buttonActive);
         outline: none; /* Remove focus outline if not needed */
       }
-      div[role="button"]:focus {
+      [role="button"]:focus {
         outline: none;
       }
-      div[role="button"] {
+      [role="button"] {
         cursor: pointer;
-      }
-      div[role="button"]:focus-visible, nav[role="button"]:focus-visible {
-        outline: 2px solid var(--buttonActive);
-        outline-offset: 2px;
       }
 
       rect:hover{
@@ -219,7 +215,7 @@
        background: var(--buttonActive);
       }
 
-      button:focus-visible, div[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+      button:focus-visible, [role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }


### PR DESCRIPTION
💡 What: Generalized CSS rules for custom buttons by changing element-specific selectors (`div[role="button"]`, `nav[role="button"]`) to generic `[role="button"]` selectors.

🎯 Why: Custom buttons injected dynamically via JavaScript (such as `span.removeButton` in the Device Hub) were failing to inherit proper pointer cursors and keyboard focus rings because the CSS was overly specific to `div` elements. This change ensures any element acting as a button behaves and looks like one.

📸 Before/After: Injected `span` buttons now receive a 2px solid ForestGreen outline on focus.

♿ Accessibility: Ensures that keyboard users receive visible focus indicators (`:focus-visible`) for all custom `role="button"` elements across the application, regardless of the underlying HTML tag.

---
*PR created automatically by Jules for task [13779389546101075477](https://jules.google.com/task/13779389546101075477) started by @ManupaKDU*