### PR TITLE
🎨 Palette: Add confirmation dialogs to destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,6 @@
 ## 2025-02-12 - File Transfer Button Disabled States
 **Learning:** In the MJPEG2SD interface, file transfer action buttons (Download, Upload, Delete) were previously left enabled even when no file was selected, leading to potential confusion or invalid actions. Furthermore, "Download" applies only to files (not folders).
 **Action:** Added default `disabled` attributes/classes to the HTML and hooked into the existing `selectFileOrFolder` JS function to dynamically toggle these states. When writing Playwright tests to verify this dynamic UI logic, elements inside inactive tabs (like `.tabcontent`) must be explicitly forced to `display: block` via JS evaluation before interaction, otherwise Playwright fails to compute their styles or interact with their children.
+## 2024-06-05 - Added Confirmation Dialogs for Destructive UI Actions
+**Learning:** Destructive actions in the UI (Reboot ESP, Clear NVS, Reload /data) were immediately triggered upon processing via `debounceSendControl` in `data/MJPEG2SD.htm` and `data/Auxil.htm`, causing potential accidental activations by users.
+**Action:** When implementing or modifying destructive UI actions in ESP32 HTML files, always wrap the action inside a `window.confirm()` dialog to ensure intentionality before dispatching the command via functions like `processStatus` or `debounceSendControl`.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -1200,6 +1200,9 @@
           else if (key == "AtakePhotos") { if (fromUser) wsAuxSend("G1", wsInd); }
           else if (key == "BabortPhotos") { if (fromUser) wsAuxSend("G0", wsInd); }
           else if (key == "AuxIP") return; // ignored
+          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; }
+          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; }
+          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; }
           else if (key == 'save') await sleep(600); // allow last input to debounce
           if (fromUser && !$('#'+key).classList.contains("local")) debounceSendControl(key, value);
         }

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1855,6 +1855,9 @@
           else if (key == "servoTiltPin") { value > 0 ? enableRangeSlider($('#camTilt')) : disableRangeSlider($('#camTilt')); }
           else if (key == "micSdPin") micState(value);
           else if (key == "mampSdIo") spkrState(value);
+          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; }
+          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; }
+          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; }
           else if (key == 'save') await sleep(600); // allow last input to debounce
           if (fromUser && !$('#'+key).classList.contains("local")) debounceSendControl(key, value);
         }


### PR DESCRIPTION
💡 What: Added confirmation dialogs to Reboot ESP, Clear NVS, and Reload /data actions in `data/MJPEG2SD.htm` and `data/Auxil.htm`.
🎯 Why: To prevent accidental destructive actions that could cause immediate reboots, wipe configurations, or disrupt the camera operations without explicit user confirmation.
📸 Before/After: Before, clicking the buttons triggered `debounceSendControl` immediately. After, a `window.confirm` dialog prompts the user, and the action is aborted if canceled.
♿ Accessibility: No significant a11y changes, but prevents accidental destructive actions from mis-clicks or keyboard navigation errors.

---
*PR created automatically by Jules for task [1657484209116843299](https://jules.google.com/task/1657484209116843299) started by @ManupaKDU*