### PR TITLE
⚡ Bolt: Replace readBytes() with read() to bypass timeout checks

### DIFF
--- a/certificates.cpp
+++ b/certificates.cpp
@@ -70,7 +70,8 @@ void loadCerts() {
         } else {
           // load contents
           serverCerts[i] = psramFound() ? (char*)ps_malloc(file.size() + 1) : (char*)malloc(file.size() + 1); 
-          size_t inBytes = file.readBytes(serverCerts[i], file.size());
+          // BOLT OPTIMIZATION: Use read() instead of readBytes() to bypass per-byte timeout checks
+          size_t inBytes = file.read((uint8_t*)serverCerts[i], file.size());
           if (inBytes != file.size()) {
             LOG_WRN("File %s not correctly loaded", certFiles[i]);
             useHttps = false;

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -115,7 +115,8 @@ static bool getTgramResponse() {
     while (contentLen - readLen > 0 && millis() - startTime < responseTimeoutSecs * 1000) {
       // retrieve response content
       size_t availLen = tclient.available();
-      if (availLen) readLen += tclient.readBytes((uint8_t*)tgramBuff + readLen, availLen);
+      // BOLT OPTIMIZATION: Use read() instead of readBytes() to bypass per-byte timeout checks
+      if (availLen) readLen += tclient.read((uint8_t*)tgramBuff + readLen, availLen);
       delay(50);
     }
     if (contentLen - readLen > 0) LOG_WRN("Timed out waiting for telegram response");


### PR DESCRIPTION
💡 What: Replaced `.readBytes()` with `.read()` in `certificates.cpp` and `telegram.cpp`. 
🎯 Why: `readBytes()` uses per-byte timeout checks (`millis()` via `timedRead()`), which introduces severe overhead during bulk I/O operations on the ESP32. 
📊 Impact: Improves stream read performance and prevents blocking during high-volume reads like certificates and Telegram API chunks. 
🔬 Measurement: Validated syntax through C++ mock testing, ran local string unit tests, and received positive code review.

---
*PR created automatically by Jules for task [13964307467744207247](https://jules.google.com/task/13964307467744207247) started by @ManupaKDU*