### PR TITLE
🎨 Palette: Generalize [role="button"] focus ring accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,7 @@
 ## 2025-02-12 - File Transfer Button Disabled States
 **Learning:** In the MJPEG2SD interface, file transfer action buttons (Download, Upload, Delete) were previously left enabled even when no file was selected, leading to potential confusion or invalid actions. Furthermore, "Download" applies only to files (not folders).
 **Action:** Added default `disabled` attributes/classes to the HTML and hooked into the existing `selectFileOrFolder` JS function to dynamically toggle these states. When writing Playwright tests to verify this dynamic UI logic, elements inside inactive tabs (like `.tabcontent`) must be explicitly forced to `display: block` via JS evaluation before interaction, otherwise Playwright fails to compute their styles or interact with their children.
+
+## 2026-06-06 - Inheritable Button Focus Styles
+**Learning:** Dynamically generated UI components lacking specific HTML tags (like `span`s acting as interactive buttons with `role="button"`) fail to inherit application-wide focus ring and cursor styling if CSS targets explicitly prefix attributes (e.g., `div[role="button"]`). This breaks accessibility visibility on custom elements injected later by scripts (like the common.js `.removeButton`).
+**Action:** Always use the generic attribute selector `[role="button"]` (without leading tags like `div` or `nav`) in core UI stylesheets (`MJPEG2SD.htm`, `Auxil.htm`) to ensure any dynamically generated accessible elements inherently adopt expected pointer behavior and keyboard `focus-visible` states.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -167,14 +167,14 @@
         ry: 15%;
       }
 
-      .buttonRect:focus, div[role="button"]:focus .buttonRect {
+      .buttonRect:focus, [role="button"]:focus .buttonRect {
         fill: var(--buttonActive);
         outline: none; /* Remove focus outline if not needed */
       }
-      div[role="button"]:focus {
+      [role="button"]:focus {
         outline: none;
       }
-      div[role="button"] {
+      [role="button"] {
         cursor: pointer;
       }
 
@@ -215,7 +215,7 @@
        background: var(--buttonActive);
       }
 
-      button:focus-visible, div[role="button"]:focus-visible, nav[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+      button:focus-visible, [role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -167,17 +167,17 @@
         ry: 15%;
       }
 
-      .buttonRect:focus, div[role="button"]:focus .buttonRect {
+      .buttonRect:focus, [role="button"]:focus .buttonRect {
         fill: var(--buttonActive);
         outline: none; /* Remove focus outline if not needed */
       }
-      div[role="button"]:focus {
+      [role="button"]:focus {
         outline: none;
       }
-      div[role="button"] {
+      [role="button"] {
         cursor: pointer;
       }
-      div[role="button"]:focus-visible, nav[role="button"]:focus-visible {
+      [role="button"]:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }
@@ -219,7 +219,7 @@
        background: var(--buttonActive);
       }
 
-      button:focus-visible, div[role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+      button:focus-visible, [role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
       }


### PR DESCRIPTION
💡 **What:** Refactored CSS selectors targeting elements with the `role="button"` attribute to omit explicit tag names (changing `div[role="button"]` to just `[role="button"]`) across the `MJPEG2SD.htm` and `Auxil.htm` stylesheets.

🎯 **Why:** Dynamically generated UI elements (like the 'x' removal button for camera IPs in `common.js`) are created as `span` tags rather than `div` tags. Although they were assigned `role="button"` and `tabindex="0"`, the tag-specific CSS selectors prevented them from inheriting the application's standard pointer cursor and high-visibility keyboard focus ring, leading to poor visual feedback for keyboard navigation.

📸 **Before/After:** Dynamically generated buttons lacking `div` tags now immediately display the default `outline: 2px solid var(--buttonActive)` when focused.

♿ **Accessibility:** This directly addresses a keyboard navigation visibility defect. Keyboard users tabbing into dynamically generated custom buttons will now clearly see which element possesses focus.

---
*PR created automatically by Jules for task [14816232369184520631](https://jules.google.com/task/14816232369184520631) started by @ManupaKDU*