### PR TITLE
⚡ Bolt: Optimize bulk Stream I/O by bypassing readBytes per-byte timer overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,7 @@
 ## 2024-05-03 - String Pointer Optimization
 **Learning:** In C/C++ applications on the ESP32, repeatedly calculating string offsets with `strlen()` during in-place string splitting loops introduces an unnecessary O(N) performance penalty.
 **Action:** When a pointer to a split character (e.g., via `strchr()`) is already computed and bounded, use pointer arithmetic (`endPtr + 1`) to advance to the remainder of the string instead of re-calculating the length (`variable + strlen(variable) + 1`).
+
+## 2024-05-18 - Replacing timedRead() loops with block read()
+**Learning:** In the ESP32/Arduino framework, `Stream::readBytes()` (used by `File`, `WiFiClientSecure`, `NetworkClientSecure`, and `I2SClass`) incurs significant performance overhead. It reads data sequentially one byte at a time and continuously calls `millis()` to check for timeouts (`timedRead()`).
+**Action:** When loading data into memory buffers from files, network sockets, or I2S peripherals, prefer block reading via `read(uint8_t* buf, size_t size)` instead of `readBytes()`. This bypasses the timer overhead and relies on the underlying subsystem's more efficient native block-read mechanisms.

--- a/audio.cpp
+++ b/audio.cpp
@@ -179,7 +179,8 @@ static size_t espMicInput() {
   // read esp mic
   size_t bytesRead = 0;
   if (micUse) {
-    bytesRead = I2Smic ? I2Sstd.readBytes((char*)sampleBuffer, sampleBytes) : I2Spdm.readBytes((char*)sampleBuffer, sampleBytes);
+    // Use block read() instead of readBytes() to bypass per-byte timer overhead for faster I/O
+    bytesRead = I2Smic ? I2Sstd.read((uint8_t*)sampleBuffer, sampleBytes) : I2Spdm.read((uint8_t*)sampleBuffer, sampleBytes);
     applyMicGain(bytesRead);
   }
   return bytesRead;

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -70,7 +70,8 @@ void loadCerts() {
         } else {
           // load contents
           serverCerts[i] = psramFound() ? (char*)ps_malloc(file.size() + 1) : (char*)malloc(file.size() + 1); 
-          size_t inBytes = file.readBytes(serverCerts[i], file.size());
+          // Use block read() instead of readBytes() to bypass per-byte timer overhead for faster I/O
+          size_t inBytes = file.read((uint8_t*)serverCerts[i], file.size());
           if (inBytes != file.size()) {
             LOG_WRN("File %s not correctly loaded", certFiles[i]);
             useHttps = false;

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -115,7 +115,8 @@ static bool getTgramResponse() {
     while (contentLen - readLen > 0 && millis() - startTime < responseTimeoutSecs * 1000) {
       // retrieve response content
       size_t availLen = tclient.available();
-      if (availLen) readLen += tclient.readBytes((uint8_t*)tgramBuff + readLen, availLen);
+      // Use block read() instead of readBytes() to bypass per-byte timer overhead for faster I/O
+      if (availLen) readLen += tclient.read((uint8_t*)tgramBuff + readLen, availLen);
       delay(50);
     }
     if (contentLen - readLen > 0) LOG_WRN("Timed out waiting for telegram response");


### PR DESCRIPTION
💡 What: Replaced usages of `Stream::readBytes()` with `read()` in `audio.cpp`, `certificates.cpp`, and `telegram.cpp` for bulk I/O operations.

🎯 Why: In the Arduino/ESP32 framework, `Stream::readBytes()` operates by reading data one byte at a time and invoking `millis()` on every single byte to check for timeouts (`timedRead()`). This busy-wait loop introduces substantial CPU overhead, especially during large buffer transfers (like loading certificates, parsing large Telegram JSON responses, or capturing I2S audio frames).

📊 Impact: Reduces CPU overhead during bulk I/O by utilizing native block-read mechanisms of the underlying subsystems (VFS for SPIFFS/SD, lwIP for sockets, and DMA for I2S audio), rather than a per-byte programmatic delay.

🔬 Measurement: Verify that audio recording, certificate loading, and Telegram API interactions continue to function without data truncation, with reduced latency during these operations.

---
*PR created automatically by Jules for task [18348138210077680110](https://jules.google.com/task/18348138210077680110) started by @ManupaKDU*