### PR TITLE
🎨 Palette: Fix keyboard interaction for SVG buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -110,3 +110,6 @@
 ## 2026-06-03 - Empty State Action Buttons UX
 **Learning:** In the `DeviceHub` interface, the "Delete All" and "Refresh" action buttons were previously left enabled even when the camera list was completely empty, allowing users to interact with buttons that had no effect.
 **Action:** Always dynamically disable action buttons associated with lists or datasets when those datasets are empty. Provide clear visual feedback by applying the native `disabled` attribute and custom disabled CSS classes, and ensure to re-enable them when data is populated.
+## 2026-06-10 - Programmatic clicks on SVG elements
+**Learning:** SVG elements (like `<rect>`) do not uniformly support the standard `.click()` method that HTMLElement objects do across all browsers. Calling `.click()` on an SVG rect inside an Enter/Space key handler fails.
+**Action:** Always use `dispatchEvent(new MouseEvent('click', { bubbles: true }))` when you need to programmatically trigger a click event on an SVG element to ensure compatibility and proper event bubbling.

--- a/data/common.js
+++ b/data/common.js
@@ -663,7 +663,7 @@
                 event.preventDefault(); // prevent scrolling for Space
                 if (e.nodeName === 'DIV') {
                   const rect = e.querySelector('rect');
-                  if (rect) rect.click();
+                  if (rect) rect.dispatchEvent(new MouseEvent('click', { bubbles: true }));
                   else e.click();
                 } else e.click();
               }


### PR DESCRIPTION
💡 What: Replaced `.click()` with a synthesized `MouseEvent` dispatch on SVG `<rect>` elements in the `common.js` keyboard event handler.
🎯 Why: SVG elements do not natively inherit the `.click()` method in all browsers. As a result, triggering an action via the Enter or Space key while focused on a custom SVG button would silently fail. This fix uses `dispatchEvent(new MouseEvent('click', { bubbles: true }))` to safely trigger the click behavior.
📸 Before/After: N/A (Functional change, no visual changes)
♿ Accessibility: Ensures that keyboard users (tabbing to the button and hitting Enter or Space) can correctly activate all SVG-based custom buttons across the interface.

---
*PR created automatically by Jules for task [13022450891195787531](https://jules.google.com/task/13022450891195787531) started by @ManupaKDU*