### PR TITLE
🎨 Palette: Add async loading, empty, and error states for application log

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -114,3 +114,6 @@
 ## 2026-06-10 - Programmatic clicks on SVG elements
 **Learning:** SVG elements (like `<rect>`) do not uniformly support the standard `.click()` method that HTMLElement objects do across all browsers. Calling `.click()` on an SVG rect inside an Enter/Space key handler fails.
 **Action:** Always use `dispatchEvent(new MouseEvent('click', { bubbles: true }))` when you need to programmatically trigger a click event on an SVG element to ensure compatibility and proper event bubbling.
+## 2025-02-20 - Add async loading and empty states to Log viewer
+**Learning:** For components that fetch data asynchronously (like logs), users may mistake an empty or slow-to-load container for a broken feature if there's no visual feedback.
+**Action:** Always provide explicit "Loading..." and "Empty" states to clearly communicate application status during asynchronous fetches.

--- a/data/common.js
+++ b/data/common.js
@@ -540,7 +540,7 @@
 
         function clearLog() {
           if (window.confirm('This will delete all log entries. Are you sure ?')) {
-            $('#appLog').innerHTML = "";
+            $('#appLog').innerHTML = '<div style="text-align:center; padding:2rem; color:var(--itemInactive); font-style:italic;">Log is currently empty</div>';
             sendControl("resetLog", "1");
           }
         }
@@ -548,7 +548,7 @@
         async function getLog() {
           // request display of stored log file
           const log = $('#appLog');
-          log.innerHTML = "";
+          log.innerHTML = '<div style="text-align:center; padding:2rem; color:var(--itemInactive); font-style:italic;">Loading log...</div>';
           const requestURL = logType == 0 ? '/control?displayLog=1' : '/web?log.txt';
           const response = await fetch(encodeURI(requestURL));
           if (response.ok) {
@@ -561,9 +561,16 @@
               htmlLines.push(colorise(logData.substring(start, index)) + '<br>');
               start = index + 1;
             }
-            log.innerHTML = htmlLines.join('');
-            log.scrollTop = log.scrollHeight;
-          } else showAlert("getLog - " + response.status + ": " + response.statusText);
+            if (htmlLines.length === 0) {
+              log.innerHTML = '<div style="text-align:center; padding:2rem; color:var(--itemInactive); font-style:italic;">Log is currently empty</div>';
+            } else {
+              log.innerHTML = htmlLines.join('');
+              log.scrollTop = log.scrollHeight;
+            }
+          } else {
+            log.innerHTML = '<div style="text-align:center; padding:2rem; color:var(--errColor); font-style:italic;">Failed to load log</div>';
+            showAlert("getLog - " + response.status + ": " + response.statusText);
+          }
         }
 
         function checkTime(value) {


### PR DESCRIPTION
💡 What: Replaced blank application log areas with explicit "Loading log...", "Log is currently empty", and "Failed to load log" text states during asynchronous file fetching.
🎯 Why: Users previously had no feedback when fetching large logs over the network or when log files were empty, leading to confusion about application status.
📸 Before/After: Before, an empty log or loading state was indistinguishable from a broken fetch (just an empty container). After, the container provides explicit text indicating the async operation state.
♿ Accessibility: Added clear textual context inside the log container so all users understand the log is either loading, empty, or failed.

---
*PR created automatically by Jules for task [1006730950590945298](https://jules.google.com/task/1006730950590945298) started by @ManupaKDU*