### PR TITLE
🎨 Palette: Explicitly expose disabled states to screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -113,3 +113,6 @@
 ## 2026-06-10 - Programmatic clicks on SVG elements
 **Learning:** SVG elements (like `<rect>`) do not uniformly support the standard `.click()` method that HTMLElement objects do across all browsers. Calling `.click()` on an SVG rect inside an Enter/Space key handler fails.
 **Action:** Always use `dispatchEvent(new MouseEvent('click', { bubbles: true }))` when you need to programmatically trigger a click event on an SVG element to ensure compatibility and proper event bubbling.
+## 2026-06-11 - Enforce aria-disabled for Dynamic UI Elements
+**Learning:** While native HTML elements like `<button>` implicitly expose their `disabled` state to accessibility APIs when the `disabled` property is set, explicitly adding `aria-disabled="true"` guarantees the state is broadcast reliably across a wider array of assistive technologies. More critically, when building custom interactive elements (like `div[role="button"]`), they do not natively support the `disabled` state. Therefore, dynamically toggling `aria-disabled="true"` in utility functions like `disable()` and `enable()` is essential to ensure custom UI components remain accessible.
+**Action:** When creating utility functions to disable UI elements, always explicitly set `el.setAttribute('aria-disabled', 'true')` and remove it when enabling, rather than relying solely on CSS classes or native properties.

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -945,7 +945,7 @@
             <li><button id="forceStream" aria-label="Start Stream" class="local" style="float:right;">➤&nbsp;Start Stream</button></li>
             <li><button id="get-still" class="local" style="float:right;" title="Capture a still image" aria-label="Capture a still image">Get Still</button></li>
             <li><div class="sep"></div></li>
-            <li><button id="forcePlayback" aria-label="Start Playback" class="local disabled" style="float:right;" title="Select a video in 'Playback & File Transfers' to activate playback." disabled>➤&nbsp;Start Playback</button></li>
+            <li><button id="forcePlayback" aria-label="Start Playback" class="local disabled" style="float:right;" title="Select a video in 'Playback & File Transfers' to activate playback." disabled aria-disabled="true">➤&nbsp;Start Playback</button></li>
           </ul>
         </nav>
       </section>
@@ -963,11 +963,11 @@
                 <nav class="quick-nav" id="picSettings" name="picture-settings" title="Picture Settings" aria-label="Picture Settings" role="button" tabindex="0">📺</nav>
                 <nav class="quick-nav" id="accSettings" name="access-settings" title="Access Settings" aria-label="Access Settings" role="button" tabindex="0">🔧</nav>
                 <div class="micContainer">
-                  <button class="quick-nav audButtons disabled" id="micRem" title="Microphone Control" aria-label="Microphone Control" disabled>🎤</button>
+                  <button class="quick-nav audButtons disabled" id="micRem" title="Microphone Control" aria-label="Microphone Control" disabled aria-disabled="true">🎤</button>
                   <canvas id="micLevel" role="meter" aria-label="Microphone volume level"></canvas>
                 </div>
                 <div class="spkrContainer">
-                  <button class="quick-nav audButtons disabled" id="spkrRem" title="Speaker Control" aria-label="Speaker Control" disabled>🔈</button>
+                  <button class="quick-nav audButtons disabled" id="spkrRem" title="Speaker Control" aria-label="Speaker Control" disabled aria-disabled="true">🔈</button>
                   <canvas id="spkrLevel" role="meter" aria-label="Speaker volume level"></canvas>
                 </div>
               </nav>
@@ -1286,9 +1286,9 @@
                   </div>
                   <br>
                   <section id="buttons">
-                    <button class="local disabled" title="Download selected file from SD card" id="download" aria-label="Download selected file" style="float:right" value="1" disabled>Download</button>
-                    <button class="local disabled" title="Upload selected file/folder to Fileserver" id="upload" aria-label="Upload selected file" style="float:left" value="1" disabled>File Upload</button>
-                    <button class="local disabled" title="Delete selected file/folder from SD card" id="delete" aria-label="Delete selected file" style="float:right" value="1" disabled>Delete</button>
+                    <button class="local disabled" title="Download selected file from SD card" id="download" aria-label="Download selected file" style="float:right" value="1" disabled aria-disabled="true">Download</button>
+                    <button class="local disabled" title="Upload selected file/folder to Fileserver" id="upload" aria-label="Upload selected file" style="float:left" value="1" disabled aria-disabled="true">File Upload</button>
+                    <button class="local disabled" title="Delete selected file/folder from SD card" id="delete" aria-label="Delete selected file" style="float:right" value="1" disabled aria-disabled="true">Delete</button>
                   </section>
   <!--
                   <div class="input-group" id="auth-group">

--- a/data/common.js
+++ b/data/common.js
@@ -468,11 +468,13 @@
         function disable(el) {
           el.classList.add('disabled');
           el.disabled = true;
+          el.setAttribute('aria-disabled', 'true');
         }
 
         function enable(el) {
           el.classList.remove('disabled');
           el.disabled = false;
+          el.removeAttribute('aria-disabled');
         }
 
         function disableRangeSlider(el) {
@@ -481,6 +483,7 @@
           rangeVal.style.background = itemInactiveColor;
           el.classList.add('disabled');
           el.disabled = true;
+          el.setAttribute('aria-disabled', 'true');
         }
 
         function enableRangeSlider(el) {
@@ -489,6 +492,7 @@
           rangeVal.style.background = itemInactiveColor;
           el.classList.remove('disabled');
           el.disabled = false;
+          el.removeAttribute('aria-disabled');
         }
 
         function isActive(el) {

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,16 @@
+1. **Update `disable` and `enable` functions in `data/common.js`**
+   - Use `run_in_bash_session` to execute a python script that reads `data/common.js` and performs a string replacement.
+   - It will update `disable(el)` and `disableRangeSlider(el)` to include `el.setAttribute('aria-disabled', 'true');` and update `enable(el)` and `enableRangeSlider(el)` to include `el.removeAttribute('aria-disabled');`.
+2. **Update initial disabled buttons in `data/MJPEG2SD.htm`**
+   - Use `run_in_bash_session` to run a python script that reads `data/MJPEG2SD.htm`.
+   - The script will use regex `re.sub(r'(\sdisabled)>', r'\1 aria-disabled="true">', content)` to add `aria-disabled="true"` to initially disabled `<button>` tags.
+3. **Verify the change**
+   - Use `run_in_bash_session` to start a local python server `python3 -m http.server 8080 &`.
+   - Write and run a Playwright python script to navigate to `http://localhost:8080/data/MJPEG2SD.htm`.
+   - It will assert that initially disabled buttons contain `aria-disabled="true"`.
+   - It will trigger `disable()` on a button via `page.evaluate` and verify that the `aria-disabled` attribute was successfully set.
+   - Kill the python server and clean up the temporary verification script.
+4. **Complete pre-commit steps**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Submit the change.**
+   - Use the `submit` tool to create a pull request with the required Palette format.

--- a/update_common.py
+++ b/update_common.py
@@ -1,0 +1,61 @@
+import sys
+
+with open('data/common.js', 'r') as f:
+    content = f.read()
+
+content = content.replace('''        function disable(el) {
+          el.classList.add('disabled');
+          el.disabled = true;
+        }
+
+        function enable(el) {
+          el.classList.remove('disabled');
+          el.disabled = false;
+        }
+
+        function disableRangeSlider(el) {
+          const rangeVal = el.parentElement.children.rangeVal;
+          const itemInactiveColor =  getComputedStyle(rangeVal).getPropertyValue('--itemInactive');
+          rangeVal.style.background = itemInactiveColor;
+          el.classList.add('disabled');
+          el.disabled = true;
+        }
+
+        function enableRangeSlider(el) {
+          const rangeVal = el.parentElement.children.rangeVal;
+          const itemInactiveColor =  getComputedStyle(rangeVal).getPropertyValue('--buttonReady');
+          rangeVal.style.background = itemInactiveColor;
+          el.classList.remove('disabled');
+          el.disabled = false;
+        }''', '''        function disable(el) {
+          el.classList.add('disabled');
+          el.disabled = true;
+          el.setAttribute('aria-disabled', 'true');
+        }
+
+        function enable(el) {
+          el.classList.remove('disabled');
+          el.disabled = false;
+          el.removeAttribute('aria-disabled');
+        }
+
+        function disableRangeSlider(el) {
+          const rangeVal = el.parentElement.children.rangeVal;
+          const itemInactiveColor =  getComputedStyle(rangeVal).getPropertyValue('--itemInactive');
+          rangeVal.style.background = itemInactiveColor;
+          el.classList.add('disabled');
+          el.disabled = true;
+          el.setAttribute('aria-disabled', 'true');
+        }
+
+        function enableRangeSlider(el) {
+          const rangeVal = el.parentElement.children.rangeVal;
+          const itemInactiveColor =  getComputedStyle(rangeVal).getPropertyValue('--buttonReady');
+          rangeVal.style.background = itemInactiveColor;
+          el.classList.remove('disabled');
+          el.disabled = false;
+          el.removeAttribute('aria-disabled');
+        }''')
+
+with open('data/common.js', 'w') as f:
+    f.write(content)

--- a/update_html.py
+++ b/update_html.py
@@ -1,0 +1,12 @@
+import sys
+import re
+
+for filename in ['data/MJPEG2SD.htm']:
+    with open(filename, 'r') as f:
+        content = f.read()
+
+    # Match `disabled>` and replace with `disabled aria-disabled="true">`
+    content = re.sub(r'(\sdisabled)>', r'\1 aria-disabled="true">', content)
+
+    with open(filename, 'w') as f:
+        f.write(content)


### PR DESCRIPTION
💡 What: Updated initially disabled interactive elements (like buttons) to include the `aria-disabled="true"` attribute and modified the dynamic `disable()` and `enable()` utility functions in `common.js` to correctly toggle this attribute.

🎯 Why: Custom interactive elements (like `div[role="button"]` or dynamically managed UI elements) do not implicitly announce their disabled state to screen readers through CSS classes or the native `disabled` property alone. Adding explicit `aria-disabled` tracking ensures screen readers reliably broadcast these element states.

📸 Before/After: Visuals remain identical (disabled state opacity and cursors). The underlying DOM updates dynamically, e.g., `<button disabled aria-disabled="true">`.

♿ Accessibility: Ensures that users relying on assistive technology are accurately informed when UI controls are disabled, preventing confusion and improving interaction flow.

---
*PR created automatically by Jules for task [13456909332535071293](https://jules.google.com/task/13456909332535071293) started by @ManupaKDU*