### PR TITLE
⚡ Bolt: Optimize O(N^2) string building in motionDetect

### DIFF
--- a/motionDetect.cpp
+++ b/motionDetect.cpp
@@ -189,8 +189,9 @@ static bool tinyMLclassify(size_t (RESIZE_DIM) {
         LOG_VRB("Prob: %0.2f, Timing: DSP %d ms, inference %d ms, anomaly %d ms", 
         result.classification[0].value, result.timing.dsp, result.timing.classification, result.timing.anomaly);
         char outcome[200] = {0};
+        char* outPtr = outcome; // ⚡ Bolt optimization: track pointer to prevent O(N^2) strlen overhead
         for (uint16_t i = 0; i < EI_CLASSIFIER_LABEL_COUNT; i++)
-          sprintf(outcome + strlen(outcome), "%s: %.2f, ", ei_classifier_inferencing_categories[i], result.classification[i].value);
+          outPtr += sprintf(outPtr, "%s: %.2f, ", ei_classifier_inferencing_categories[i], result.classification[i].value);
         LOG_VRB("Predictions - %s in %ums", outcome, millis() - dTime);
       } 
     } 


### PR DESCRIPTION
### 💡 What
Optimized the string building logic inside `checkMotion` in `motionDetect.cpp`. Introduced an `outPtr` tracking variable that captures the return value of `sprintf` (which returns the number of characters written) to efficiently append to the `outcome` buffer in O(1) time per iteration.

### 🎯 Why
The original code used `sprintf(outcome + strlen(outcome), ...)` inside a loop. Since `strlen` has to traverse the increasingly large `outcome` string from the beginning on every single iteration, this creates an O(N²) time complexity bottleneck (Schlemiel the Painter's algorithm).

### 📊 Impact
Reduces string concatenation overhead from O(N²) to O(N). While this specifically runs when `dbgVerbose` is enabled, reducing unnecessary instruction cycles during high-frequency motion detection events frees up the ESP32 CPU for critical tasks like image processing and TinyML inference.

### 🔬 Measurement
Compiled and executed a standalone mock C++ test that validated the optimized implementation produces the exact same output formatting as the original implementation, confirming functional parity while preventing the redundant string length recalculations.

---
*PR created automatically by Jules for task [13352172667698534972](https://jules.google.com/task/13352172667698534972) started by @ManupaKDU*