### PR TITLE
⚡ Bolt: O(N^2) string formatting overhead in checkMotion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -82,3 +82,6 @@
 ## 2024-05-29 - Block reads bypass timedRead overhead
 **Learning:** In the ESP32/Arduino framework, `Stream::readBytes()` (used by `File` and `WiFiClientSecure`) incurs significant performance overhead due to per-byte timeout checks (`millis()` via `timedRead()`). This is essentially an O(N) overhead layer around what could be a block read.
 **Action:** When loading data into memory buffers where the size is known or we want to read everything available, prefer block reading via `read(uint8_t* buf, size_t size)` over `readBytes()` to bypass this timer overhead and drastically improve bulk I/O performance.
+## 2026-05-21 - O(N^2) strlen overhead in tight inner formatting loops
+**Learning:** Found a performance bottleneck inside `checkMotion` in `motionDetect.cpp` where `strlen()` was being called repeatedly inside an inner loop iterating over the `EI_CLASSIFIER_LABEL_COUNT`. `sprintf(outcome + strlen(outcome), ...)` forces the string to be traversed completely on every single append, yielding an O(N^2) complexity that unnecessarily wastes CPU cycles in a tight ML processing path.
+**Action:** Replaced the `strlen(outcome)` with a managed `offset` variable, transforming the loop concatenation to `snprintf(outcome + offset, remaining, ...)`, making the operation O(1) per iteration while simultaneously preventing potential buffer overflows.

--- a/motionDetect.cpp
+++ b/motionDetect.cpp
@@ -189,8 +189,14 @@ static bool tinyMLclassify(size_t (RESIZE_DIM) {
         LOG_VRB("Prob: %0.2f, Timing: DSP %d ms, inference %d ms, anomaly %d ms", 
         result.classification[0].value, result.timing.dsp, result.timing.classification, result.timing.anomaly);
         char outcome[200] = {0};
-        for (uint16_t i = 0; i < EI_CLASSIFIER_LABEL_COUNT; i++)
-          sprintf(outcome + strlen(outcome), "%s: %.2f, ", ei_classifier_inferencing_categories[i], result.classification[i].value);
+        int offset = 0; // ⚡ Bolt optimization: Track offset to avoid O(N^2) Schlemiel the Painter's algorithm from strlen
+        for (uint16_t i = 0; i < EI_CLASSIFIER_LABEL_COUNT; i++) {
+          int remaining = sizeof(outcome) - offset;
+          if (remaining <= 0) break;
+          int written = snprintf(outcome + offset, remaining, "%s: %.2f, ", ei_classifier_inferencing_categories[i], result.classification[i].value);
+          if (written > 0 && written < remaining) offset += written;
+          else break;
+        }
         LOG_VRB("Predictions - %s in %ums", outcome, millis() - dTime);
       } 
     } 


### PR DESCRIPTION
💡 What: Replaced `sprintf(outcome + strlen(outcome))` with `snprintf(outcome + offset)` in the `checkMotion` ML classification formatting loop.
🎯 Why: Calling `strlen()` on an ever-growing string inside a loop forces a full string traversal on every iteration, causing O(N^2) complexity (Schlemiel the Painter's algorithm). On an ESP32, this wastes critical CPU cycles inside tight processing paths.
📊 Impact: Reduces time complexity of string formatting from O(N^2) to O(N). Also improves stability by explicitly using `snprintf` and preventing potential buffer overflows.
🔬 Measurement: Verified functionality by extracting logic into a standalone C++ program and compiling. Ensured no regressions by running the stringUtils test suite. Verified code changes didn't corrupt line endings.

---
*PR created automatically by Jules for task [11184143494330900591](https://jules.google.com/task/11184143494330900591) started by @ManupaKDU*