### PR TITLE
⚡ Bolt: Fix O(N^2) string formatting in motionDetect.cpp

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,6 @@
 ## 2024-05-03 - String Pointer Optimization
 **Learning:** In C/C++ applications on the ESP32, repeatedly calculating string offsets with `strlen()` during in-place string splitting loops introduces an unnecessary O(N) performance penalty.
 **Action:** When a pointer to a split character (e.g., via `strchr()`) is already computed and bounded, use pointer arithmetic (`endPtr + 1`) to advance to the remainder of the string instead of re-calculating the length (`variable + strlen(variable) + 1`).
+## 2025-02-13 - Avoid O(N^2) strlen overhead in classification loop
+**Learning:** In `motionDetect.cpp`, calling `strlen()` inside the loop used to format the classification outcome (`sprintf(outcome + strlen(outcome), ...)`) recalculates the string length on every iteration, leading to O(N^2) Schlemiel the Painter's Algorithm performance.
+**Action:** Replaced the loop `strlen` and `sprintf` with an explicit `offset` tracker and `snprintf`.

--- a/motionDetect.cpp
+++ b/motionDetect.cpp
@@ -1,8 +1,8 @@
 
-/* 
+/*
  Detect movement in sequential images using background subtraction.
- 
- Very small (96x96) bitmaps are used both to provide image smoothing to reduce spurious motion changes 
+
+ Very small (96x96) bitmaps are used both to provide image smoothing to reduce spurious motion changes
  and to enable rapid processing
  Bitmaps can either be color or grayscale. Color requires triple memory
  of grayscale and more processing.
@@ -10,13 +10,13 @@
  The amount of change between images will depend on the frame rate.
  A faster frame rate will need a higher sensitivity
 
- When frame size is changed the OV2640 outputs a few glitched frames whilst it 
+ When frame size is changed the OV2640 outputs a few glitched frames whilst it
  makes the transition. These could be interpreted as spurious motion.
 
- Machine Learning can be incorporated to further discriminate when motion detection 
+ Machine Learning can be incorporated to further discriminate when motion detection
  has occurred by classifying whether the object in the frame is of a particular
- type of interest, eg a human, animal, vehicle etc. 
- 
+ type of interest, eg a human, animal, vehicle etc.
+
  s60sc 2020, 2023, 2025
 */
 
@@ -28,10 +28,10 @@
 
 #define INACTIVE_COLOR 96 // color for inactive motion pixel
 #define JPEG_QUAL 80 // % quality for generated motion detect jpeg
-  
+
 // motion recording parameters
 bool dbgMotion = false;
-int detectMotionFrames = 5; // min sequence of changed frames to confirm motion 
+int detectMotionFrames = 5; // min sequence of changed frames to confirm motion
 int detectNightFrames = 10; // frames of sequential darkness to avoid spurious day / night switching
 // define region of interest, ie exclude top and bottom of image from movement detection if required
 // divide image into detectNumBands horizontal bands, define start and end bands of interest, 1 = top
@@ -44,7 +44,7 @@ static size_t stride;
 bool mlUse = false; // whether to use ML for motion detection, requires INCLUDE_TINYML to be true
 float mlProbability = 0.8; // minimum probability (0.0 - 1.0) for positive classification
 
-uint8_t lightLevel; // Current ambient light level 
+uint8_t lightLevel; // Current ambient light level
 uint8_t nightSwitch = 20; // initial white level % for night/day switching
 float motionVal = 8.0; // initial motion sensitivity setting
 uint8_t* motionJpeg = NULL;
@@ -100,15 +100,15 @@ bool isNight(uint8_t nightSwitch) {
       nightCnt++;
       // signal night time after given sequence of dark frames
       if (nightCnt > detectNightFrames) {
-        nightTime = true;     
-        nightCnt = detectNightFrames;           
-        LOG_INF("Night time"); 
+        nightTime = true;
+        nightCnt = detectNightFrames;
+        LOG_INF("Night time");
       }
     } else {
       // back to light while not yet in nightTime: reset counter
       if (nightCnt > 0) nightCnt--;
     }
-  } 
+  }
   return nightTime;
 }
 
@@ -155,18 +155,18 @@ static int getImageData(size_t offset, size_t length, float *out_ptr) {
   size_t pixelPtr = offset * colorDepth;
   size_t out_ptr_idx = 0;
   while (out_ptr_idx < length) {
-    out_ptr[out_ptr_idx++] = (colorDepth == RGB888_BYTES)  
+    out_ptr[out_ptr_idx++] = (colorDepth == RGB888_BYTES)
       ? (float)((currBuff[pixelPtr] << 16) + (currBuff[pixelPtr + 1] << 8) + currBuff[pixelPtr + 2])
-      : (float)((currBuff[pixelPtr] << 16) + (currBuff[pixelPtr] << 8) + currBuff[pixelPtr]);  
+      : (float)((currBuff[pixelPtr] << 16) + (currBuff[pixelPtr] << 8) + currBuff[pixelPtr]);
     pixelPtr += colorDepth;
-  } 
+  }
   return 0;
 }
 
 static bool tinyMLclassify(size_t (RESIZE_DIM) {
   // convert input data to appropriate format
   bool out = false;
-  uint32_t dTime = millis(); 
+  uint32_t dTime = millis();
   // reduce size of bitmap to that required by classifier and copy to features as grayscale or RGB
   if (RESIZE_DIM != EI_CLASSIFIER_INPUT_WIDTH) {
     size_t tempSize = EI_CLASSIFIER_INPUT_WIDTH * EI_CLASSIFIER_INPUT_HEIGHT * colorDepth;
@@ -186,14 +186,27 @@ static bool tinyMLclassify(size_t (RESIZE_DIM) {
     if (result.classification[0].value > mlProbability) {
       out = true; // sufficient classification match, so keep motion detection
       if (dbgVerbose) {
-        LOG_VRB("Prob: %0.2f, Timing: DSP %d ms, inference %d ms, anomaly %d ms", 
+        LOG_VRB("Prob: %0.2f, Timing: DSP %d ms, inference %d ms, anomaly %d ms",
         result.classification[0].value, result.timing.dsp, result.timing.classification, result.timing.anomaly);
         char outcome[200] = {0};
-        for (uint16_t i = 0; i < EI_CLASSIFIER_LABEL_COUNT; i++)
-          sprintf(outcome + strlen(outcome), "%s: %.2f, ", ei_classifier_inferencing_categories[i], result.classification[i].value);
+        int offset = 0;
+        for (uint16_t i = 0; i < EI_CLASSIFIER_LABEL_COUNT; i++) {
+          int remaining = sizeof(outcome) - offset;
+          if (remaining > 0) {
+            // Track offset to avoid O(N^2) strlen calls and prevent buffer overflows
+            int written = snprintf(outcome + offset, remaining, "%s: %.2f, ", ei_classifier_inferencing_categories[i], result.classification[i].value);
+            if (written > 0) {
+                if (written < remaining) {
+                    offset += written;
+                } else {
+                    break;
+                }
+            }
+          }
+        }
         LOG_VRB("Predictions - %s in %ums", outcome, millis() - dTime);
-      } 
-    } 
+      }
+    }
   } else LOG_WRN("Failed to run classifier (%d)", res);
   return out;
 }
@@ -209,7 +222,7 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
     firstCall = false;
   }
   size_t RESIZE_DIM_SQ = (RESIZE_DIM * RESIZE_DIM); // pixels in bitmap
-  
+
   if (fsizePtr > FRAMESIZE_SXGA) return false;
   uint32_t dTime = millis();
   uint32_t lux = 0;
@@ -222,12 +235,12 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
  #if INCLUDE_NEW_JPG
   static struct esp_jpeg_stream jpegHandle = {0};
   static uint8_t* jpgBuf = (uint8_t*)ps_malloc(RESIZE_DIM_SQ * RGB888_BYTES);
-#endif  
+#endif
 
   // calculate parameters for sample size when resolution changes
   if (fsizePtr != fsizePtrPrev) {
     fsizePtrPrev = fsizePtr;
-    scaling = frameData[fsizePtr].scaleFactor; 
+    scaling = frameData[fsizePtr].scaleFactor;
     reducer = frameData[fsizePtr].sampleRate;
     downsize = pow(2, scaling) * reducer;
     stride = (colorDepth == RGB888_BYTES) ? GRAYSCALE_BYTES : RGB888_BYTES; // stride is inverse of colorDepth
@@ -249,21 +262,21 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
   if (colorDepth == GRAYSCALE_BYTES) rgbToGray(rgbBuf, sampleWidth, sampleHeight);
 #endif
   LOG_VRB("JPEG to rescaled %s bitmap conversion %u bytes in %lums", colorDepth == RGB888_BYTES ? "color" : "grayscale", sampleWidth * sampleHeight * colorDepth, millis() - dTime);
-  
+
   // allocate buffer space on heap
   size_t resizeDimLen = RESIZE_DIM_SQ * colorDepth; // byte size of bitmap
   if (motionJpeg == NULL) motionJpeg = (uint8_t*)ps_malloc(32 * 1024);
   if (currBuff == NULL) currBuff = (uint8_t*)ps_malloc(RESIZE_DIM_SQ * RGB888_BYTES);
   static uint8_t* prevBuff = (uint8_t*)ps_malloc(RESIZE_DIM_SQ * RGB888_BYTES);
   static uint8_t* changeMap = (uint8_t*)ps_malloc(RESIZE_DIM_SQ * RGB888_BYTES);
-  
+
   dTime = millis();
   rescaleImage(rgbBuf, sampleWidth, sampleHeight, currBuff, RESIZE_DIM, RESIZE_DIM);
   LOG_VRB("Bitmap rescale to %u bytes in %lums", resizeDimLen, millis() - dTime);
-  // compare each pixel in current frame with previous frame 
+  // compare each pixel in current frame with previous frame
   dTime = millis();
   int changeCount = 0;
-  // set horizontal region of interest in image 
+  // set horizontal region of interest in image
   uint16_t startPixel = (RESIZE_DIM*(detectStartBand-1)/detectNumBands) * RESIZE_DIM * colorDepth;
   uint16_t endPixel = (RESIZE_DIM*(detectEndBand)/detectNumBands) * RESIZE_DIM * colorDepth;
   int moveThreshold = max(1, (int)(((endPixel - startPixel) / colorDepth) * (11 - motionVal) / 100)); // number of changed pixels that constitute a movement
@@ -292,7 +305,7 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
 
   lightLevel = (lux*100)/(RESIZE_DIM_SQ*255); // light value as a %
   nightTime = isNight(nightSwitch);
-  memcpy(prevBuff, currBuff, resizeDimLen); // save image for next comparison 
+  memcpy(prevBuff, currBuff, resizeDimLen); // save image for next comparison
   LOG_VRB("Detected %u changes, threshold %u, light level %u, in %lums", changeCount, moveThreshold, lightLevel, millis() - dTime);
   if (lightLevelOnly) return false; // no motion checking, only calc of light level
   if (dbgMotion) {
@@ -303,13 +316,13 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
       // build jpeg of changeMap for debug streaming
 #if INCLUDE_NEW_JPG
       motionJpegLen = rgb2jpg(changeMap, RESIZE_DIM, RESIZE_DIM, JPEG_QUAL, jpgBuf);
-      if (motionJpegLen == 0) LOG_WRN("motionDetect: encode() failed"); 
-      else memcpy(motionJpeg, jpgBuf, motionJpegLen); 
+      if (motionJpegLen == 0) LOG_WRN("motionDetect: encode() failed");
+      else memcpy(motionJpeg, jpgBuf, motionJpegLen);
 #else
       uint8_t* jpg_buf = NULL;
       if (!fmt2jpg(changeMap, resizeDimLen, RESIZE_DIM, RESIZE_DIM, PIXFORMAT_RGB888, JPEG_QUAL, &jpg_buf, &motionJpegLen))
-        LOG_WRN("motionDetect: fmt2jpg() failed"); 
-      else memcpy(motionJpeg, jpg_buf, motionJpegLen); 
+        LOG_WRN("motionDetect: fmt2jpg() failed");
+      else memcpy(motionJpeg, jpg_buf, motionJpegLen);
       free(jpg_buf);
       jpg_buf = NULL;
 #endif
@@ -344,9 +357,9 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
 #endif
         }
 #endif
-      } 
+      }
     } else motionCnt = 0;
-  
+
     if (motionStatus && !motionCnt) {
       // insufficient change or motion not classified
       LOG_VRB("***** Motion - STOP");
@@ -358,10 +371,10 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
         mqttPublishPath("motion", "off");
       }
 #endif
-    } 
+    }
     if (motionStatus) LOG_VRB("*** Motion - ongoing %lu frames", motionCnt);
   }
-  
+
   if (dbgVerbose) checkMemory();
   LOG_VRB("============================");
   // motionStatus indicates whether motion previously ongoing or not
@@ -377,7 +390,7 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
 static void jpgReduce(int inWidth, int inHeight, uint8_t downsize, int* outWidth, int* outHeight) {
   // downsize then round width and height up to the nearest multiple of 8 while preserving the aspect ratio
   uint8_t roundTo8 = 8; // new width and height must be multiples of 8
-  // Calculate the original aspect ratio 
+  // Calculate the original aspect ratio
   inWidth /= downsize;
   inHeight /= downsize;
   float aspectRatio = (float)(inWidth) / inHeight;
@@ -389,7 +402,7 @@ static void jpgReduce(int inWidth, int inHeight, uint8_t downsize, int* outWidth
 
   // determine larger dimension
   int newLarger = inWidth;
-  int newSmaller = inHeight;   
+  int newSmaller = inHeight;
   if (inWidth < inHeight) {
     newLarger = inHeight;
     newSmaller = inWidth;
@@ -397,7 +410,7 @@ static void jpgReduce(int inWidth, int inHeight, uint8_t downsize, int* outWidth
 
   // Round the larger dimension up to the nearest multiple of 8.
   newLarger = roundUpToMultiple(inWidth, roundTo8);
-  
+
   // Calculate the new smaller based on the new larger and original aspect ratio, then round up.
   newSmaller = (int)(ceil((float)newLarger / aspectRatio));
   newSmaller = roundUpToMultiple(newSmaller, roundTo8);
@@ -538,7 +551,7 @@ static bool jpg2rgb(const uint8_t* src, size_t src_len, uint8_t* out, uint8_t sc
   };
   esp_jpeg_image_output_t output_img = {};
   esp_err_t res = esp_jpeg_decode(&jpeg_cfg, &output_img);
-  if (res != ESP_OK) LOG_WRN("jpg2rgb failure: %s", espErrMsg(res)); 
+  if (res != ESP_OK) LOG_WRN("jpg2rgb failure: %s", espErrMsg(res));
   return (res == ESP_OK);
 }
 
@@ -564,7 +577,7 @@ static bool _rgb_write(void * arg, uint16_t x, uint16_t y, uint16_t w, uint16_t 
       // write start
       jpeg->width = w;
       jpeg->height = h;
-    } 
+    }
     return true;
   }
 
@@ -608,7 +621,7 @@ static bool jpg2rgb(const uint8_t* src, size_t src_len, uint8_t* out, uint8_t sc
   jpeg.output = out;
   jpeg.data_offset = 0;
   esp_err_t res = esp_jpg_decode(src_len, (jpg_scale_t)scale, _jpg_read, _rgb_write, (void*)&jpeg);
-  if (res != ESP_OK) LOG_WRN("jpg2rgb failure: %s", espErrMsg(res)); 
+  if (res != ESP_OK) LOG_WRN("jpg2rgb failure: %s", espErrMsg(res));
   return (res == ESP_OK);
 }
 
@@ -616,9 +629,8 @@ static bool jpg2rgb(const uint8_t* src, size_t src_len, uint8_t* out, uint8_t sc
 
 #endif // INCLUDE_NEW_JPG
 
-#else 
+#else
 // dummies
 bool isNight(uint8_t nightSwitch) {return false;}
 
 #endif // AUXILIARY
-


### PR DESCRIPTION
💡 What: Replace `strlen()` inside a `sprintf` loop in `motionDetect.cpp` with an explicitly tracked `offset` variable and `snprintf`.
🎯 Why: Calling `strlen()` on the dynamically growing buffer inside the loop recalculates the string length on every iteration. This forces an O(N^2) traversal (Schlemiel the Painter's Algorithm), degrading performance. Tracking the explicit write offset brings this back down to O(N).
📊 Impact: Eliminates redundant O(N) string traversals in the inner ML classification loop, slightly improving execution speed and significantly improving buffer bounds safety via `snprintf`.
🔬 Measurement: Verify tests run successfully. The same formatting logic behavior was tested in an isolated mock C++ environment.

---
*PR created automatically by Jules for task [6697826851773722828](https://jules.google.com/task/6697826851773722828) started by @ManupaKDU*