### PR TITLE
🎨 Palette: [UX] Add visual feedback alerts for critical device actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -117,3 +117,6 @@
 ## 2025-02-20 - Add async loading and empty states to Log viewer
 **Learning:** For components that fetch data asynchronously (like logs), users may mistake an empty or slow-to-load container for a broken feature if there's no visual feedback.
 **Action:** Always provide explicit "Loading..." and "Empty" states to clearly communicate application status during asynchronous fetches.
+## 2026-06-14 - Alert Text Race Conditions and Visual Feedback
+**Learning:** `showAlert` functions using async `await sleep(x)` calls without tracking timers will cause later alerts to be prematurely cleared by the timer of a previous alert. Also, important setup actions like Reset, Save, and Clear NVS often complete their JS logic instantly, leaving the UI state ambiguous before a device reboot.
+**Action:** When creating UI alerts, manage setTimeout handles (e.g. `clearTimeout(alertTimer)`) so multiple invocations don't clash. Always provide immediate UI feedback (like `showAlert('Saving...')`) when a critical configuration action begins.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -1212,9 +1212,9 @@
           else if (key == "AtakePhotos") { if (fromUser) wsAuxSend("G1", wsInd); }
           else if (key == "BabortPhotos") { if (fromUser) wsAuxSend("G0", wsInd); }
           else if (key == "AuxIP") return; // ignored
-          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; }
-          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; }
-          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; }
+          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; showAlert("Rebooting ESP..."); }
+          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; showAlert("Clearing NVS..."); }
+          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; showAlert("Reloading /data..."); }
           else if (key == 'save') await sleep(600); // allow last input to debounce
           if (fromUser && !$('#'+key).classList.contains("local")) {
             if (key == "clear" && !confirm("Are you sure you want to clear NVS?")) return;

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1867,9 +1867,9 @@
           else if (key == "servoTiltPin") { value > 0 ? enableRangeSlider($('#camTilt')) : disableRangeSlider($('#camTilt')); }
           else if (key == "micSdPin") micState(value);
           else if (key == "mampSdIo") spkrState(value);
-          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; }
-          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; }
-          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; }
+          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; showAlert("Rebooting ESP..."); }
+          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; showAlert("Clearing NVS..."); }
+          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; showAlert("Reloading /data..."); }
           else if (key == 'save') await sleep(600); // allow last input to debounce
           if (fromUser && !$('#'+key).classList.contains("local")) {
             if (key == "clear" && !confirm("Are you sure you want to clear NVS?")) return;

--- a/data/common.js
+++ b/data/common.js
@@ -33,6 +33,7 @@
         let pageVisible = true;
         let logType = 0;
         let isBuilt = false; // for one off build of Main tab
+        let alertTimer = null;
 
         async function initialise() {
           try {
@@ -505,8 +506,10 @@
 
         async function showAlert(value) {
           $('#alertText').innerHTML = value;
-          await sleep(5000);
-          $('#alertText').innerHTML = "";
+          if (alertTimer) clearTimeout(alertTimer);
+          alertTimer = setTimeout(() => {
+            $('#alertText').innerHTML = "";
+          }, 5000);
         }
 
         async function saveChanges(resetMsg = "User requested restart") {
@@ -521,9 +524,11 @@
             }
           }
           // save change and reboot
+          showAlert('Saving settings...');
           await sleep(100);
           sendControl('save', 1);
           await sleep(1000);
+          showAlert('Rebooting device...');
           sendControl('reset', resetMsg);
         }
 


### PR DESCRIPTION
## 💡 What
Added immediate, on-screen visual feedback (toast alerts) for critical configuration actions (Save Settings, Reboot ESP, Clear NVS, Reload /data). Additionally, refactored the `showAlert` function to properly handle concurrent requests by managing `setTimeout` handles instead of relying on blocking `await sleep()` calls.

## 🎯 Why
Previously, when users clicked buttons for actions like "Reboot ESP" or "Save", the JavaScript logic executed immediately but the device would take several seconds to reboot. During this time, there was no visual indication that the button click was registered, making the UI feel unresponsive and leading to potential frustration or repeated clicks.

Additionally, the old `showAlert` implementation had a race condition: if an alert was triggered while another was already waiting its `sleep(5000)`, the older timeout would expire and clear the newer alert's text instantly.

## 📸 Before/After
**Before:** Clicking "Reboot ESP" or "Save" did not immediately alter the UI; users just had to wait for the device to reset.
**After:** Clicking these buttons instantly shows "Rebooting ESP..." or "Saving settings..." -> "Rebooting device..." in the bottom alert banner, confirming the action.

## ♿ Accessibility
The alerts are written to `#alertText`, which is inside an `<div class="alertMsg" role="alert" aria-live="assertive">` container. This ensures that screen readers immediately announce these critical state changes (like "Rebooting ESP...") to the user as soon as the text updates.

---
*PR created automatically by Jules for task [6523526273054520516](https://jules.google.com/task/6523526273054520516) started by @ManupaKDU*