### PR TITLE
🎨 Palette: Improve accessibility of disabled interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -117,3 +117,6 @@
 ## 2025-02-20 - Add async loading and empty states to Log viewer
 **Learning:** For components that fetch data asynchronously (like logs), users may mistake an empty or slow-to-load container for a broken feature if there's no visual feedback.
 **Action:** Always provide explicit "Loading..." and "Empty" states to clearly communicate application status during asynchronous fetches.
+## 2026-06-16 - Ensure custom elements correctly announce disabled state
+**Learning:** In the ESP32 HTML files (`MJPEG2SD.htm`, `Auxil.htm`) and JavaScript (`common.js`), when programmatically disabling custom interactive elements (like `<div role="button">` or `<nav>`), relying solely on the native `disabled` property or CSS classes is insufficient for screen readers.
+**Action:** Always explicitly toggle the `aria-disabled="true"` attribute via Javascript (`el.setAttribute('aria-disabled', 'true');` and `el.removeAttribute('aria-disabled');`) when custom UI elements are disabled or enabled to ensure proper screen reader announcements.

--- a/data/common.js
+++ b/data/common.js
@@ -468,11 +468,13 @@
         function disable(el) {
           el.classList.add('disabled');
           el.disabled = true;
+          el.setAttribute('aria-disabled', 'true');
         }
 
         function enable(el) {
           el.classList.remove('disabled');
           el.disabled = false;
+          el.removeAttribute('aria-disabled');
         }
 
         function disableRangeSlider(el) {
@@ -481,6 +483,7 @@
           rangeVal.style.background = itemInactiveColor;
           el.classList.add('disabled');
           el.disabled = true;
+          el.setAttribute('aria-disabled', 'true');
         }
 
         function enableRangeSlider(el) {
@@ -489,6 +492,7 @@
           rangeVal.style.background = itemInactiveColor;
           el.classList.remove('disabled');
           el.disabled = false;
+          el.removeAttribute('aria-disabled');
         }
 
         function isActive(el) {


### PR DESCRIPTION
💡 What: Modified `disable` and `enable` functions in `data/common.js` to explicitly toggle the `aria-disabled` attribute.
🎯 Why: Relying solely on the `disabled` property or CSS classes for custom interactive elements (like `div[role="button"]`) is insufficient for screen readers. Explicitly toggling `aria-disabled` ensures screen readers accurately announce the element's disabled state.
📸 Before/After: Verified functionally through Playwright script asserting the DOM correctly toggles `aria-disabled="true"`.
♿ Accessibility: Ensures custom interactive elements (like sliders and toolbars) correctly announce their disabled state to assistive technologies.

---
*PR created automatically by Jules for task [8659802953482477148](https://jules.google.com/task/8659802953482477148) started by @ManupaKDU*