### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in WebDAV Move

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -112,3 +112,7 @@
 **Vulnerability:** A critical buffer overflow risk was identified in `mqtt.cpp` where `sprintf(remoteQuery, "%.*s", event->data_len, (char*)event->data)` was used to copy an incoming MQTT payload into a statically sized array `remoteQuery` (`FILE_NAME_LEN * 2`). Because the payload length (`event->data_len`) is controlled by the external MQTT broker and could exceed the buffer bounds, a buffer overflow could occur.
 **Learning:** External inputs like MQTT payloads should never be copied into bounded arrays without proper length checks. Using `sprintf` for dynamically sized external data is unsafe and allows buffer overflow vulnerabilities.
 **Prevention:** Always use safe bounded string functions like `snprintf` when copying dynamically sized inputs into static buffers, passing the buffer's size explicitly using `sizeof(buffer)`.
+## 2024-06-16 - Path Traversal via WebDAV Destination Header
+**Vulnerability:** In `webDav.cpp`, the `handleMove` function extracted the `Destination` header, decoded it, and used it directly in a `STORAGE.rename` call without checking for path traversal sequences like `../`.
+**Learning:** Any input derived from HTTP headers that will be used in filesystem operations must be validated against directory traversal, especially after URL decoding, as it provides an alternative vector to URI-based parameters.
+**Prevention:** Always validate extracted header values that represent file paths using `isPathTraversal` (after calling `urlDecode`) before performing any storage operations (like rename/move/copy).

--- a/webDav.cpp
+++ b/webDav.cpp
@@ -29,6 +29,7 @@
 */
 
 #include "appGlobals.h"
+#include "stringUtils.h"
 
 #if INCLUDE_WEBDAV
 #define ALLOW "PROPPATCH,PROPFIND,OPTIONS,DELETE,MOVE,COPY,HEAD,POST,PUT,GET"
@@ -287,6 +288,10 @@ static bool handleMove() {
     // obtain destination filename
     res = true;
     urlDecode(dest);
+    if (isPathTraversal(dest)) {
+      httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Path traversal not allowed");
+      return false;
+    }
     char* pos = strstr(dest, WEBDAV);
     if (!pos) {
       httpd_resp_send_404(req);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The WebDAV `MOVE` method implementation extracted and URL-decoded the `Destination` header, but did not perform any checks for path traversal sequences like `../` before calling the underlying `STORAGE.rename` function. This allowed an attacker to move files outside of the intended WebDAV root folder.
🎯 Impact: An attacker could perform arbitrary file modifications by renaming or moving files to sensitive locations outside the WebDAV root, potentially leading to unauthorized system access, data overwrite, or deletion.
🔧 Fix: In `webDav.cpp`, included `stringUtils.h` and explicitly added a validation check using the centralized `isPathTraversal` function right after decoding the `dest` path. If traversal is detected, it immediately sends a 404/Bad Request error and aborts the rename operation.
✅ Verification: Added and ran a standalone mock `test_mock3.cpp` testing the extraction and validation logic. The mock successfully intercepted a `/webdav/../etc/passwd` payload and correctly simulated returning a 404. Also successfully ran `pnpm test` equivalent on `stringUtils.cpp` directly.

---
*PR created automatically by Jules for task [17990844622937784788](https://jules.google.com/task/17990844622937784788) started by @ManupaKDU*