### PR TITLE
🎨 Palette: Add visual feedback for long-running actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -117,3 +117,7 @@
 ## 2025-02-20 - Add async loading and empty states to Log viewer
 **Learning:** For components that fetch data asynchronously (like logs), users may mistake an empty or slow-to-load container for a broken feature if there's no visual feedback.
 **Action:** Always provide explicit "Loading..." and "Empty" states to clearly communicate application status during asynchronous fetches.
+
+## 2024-06-18 - Add instant visual feedback for device actions
+**Learning:** In the ESP32 app, long-running actions (Reset, Clear NVS, Reload /data) will make the interface appear unresponsive before the backend completes or reboots. The UI provides `showAlert()` but we need to use it right when an action is confirmed to assure users something is happening.
+**Action:** Always invoke `showAlert()` immediately before dispatching long-running backend calls like `sendControl` for disruptive actions.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -1212,14 +1212,11 @@
           else if (key == "AtakePhotos") { if (fromUser) wsAuxSend("G1", wsInd); }
           else if (key == "BabortPhotos") { if (fromUser) wsAuxSend("G0", wsInd); }
           else if (key == "AuxIP") return; // ignored
-          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; }
-          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; }
-          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; }
-          else if (key == 'save') await sleep(600); // allow last input to debounce
+          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; showAlert("Rebooting ESP..."); }
+          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; showAlert("Clearing NVS..."); }
+          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; showAlert("Reloading /data..."); }
+          else if (key == 'save') { showAlert("Saving..."); await sleep(600); } // allow last input to debounce
           if (fromUser && !$('#'+key).classList.contains("local")) {
-            if (key == "clear" && !confirm("Are you sure you want to clear NVS?")) return;
-            if (key == "deldata" && !confirm("Are you sure you want to reload /data?")) return;
-            if (key == "reset" && !confirm("Are you sure you want to reboot the ESP?")) return;
             debounceSendControl(key, value);
           }
         }

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1867,14 +1867,11 @@
           else if (key == "servoTiltPin") { value > 0 ? enableRangeSlider($('#camTilt')) : disableRangeSlider($('#camTilt')); }
           else if (key == "micSdPin") micState(value);
           else if (key == "mampSdIo") spkrState(value);
-          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; }
-          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; }
-          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; }
-          else if (key == 'save') await sleep(600); // allow last input to debounce
+          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; showAlert("Rebooting ESP..."); }
+          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; showAlert("Clearing NVS..."); }
+          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; showAlert("Reloading /data..."); }
+          else if (key == 'save') { showAlert("Saving..."); await sleep(600); } // allow last input to debounce
           if (fromUser && !$('#'+key).classList.contains("local")) {
-            if (key == "clear" && !confirm("Are you sure you want to clear NVS?")) return;
-            if (key == "deldata" && !confirm("Are you sure you want to reload /data?")) return;
-            if (key == "reset" && !confirm("Are you sure you want to reboot the ESP?")) return;
             debounceSendControl(key, value);
           }
         }

--- a/data/common.js
+++ b/data/common.js
@@ -521,6 +521,7 @@
             }
           }
           // save change and reboot
+          showAlert('Saving changes and rebooting...');
           await sleep(100);
           sendControl('save', 1);
           await sleep(1000);


### PR DESCRIPTION
💡 What
Added immediate visual feedback via `showAlert` for destructive/long-running device actions (Reboot, Clear NVS, Reload /data, and Save Settings).

🎯 Why
When triggering these long-running operations from the ESP32 UI, the application waits for the backend to complete or the device to restart, causing the interface to appear completely unresponsive and frozen in the meantime. By adding immediate feedback upon user confirmation, users are reassured that their action is being processed.

📸 Before/After
Before: After confirming a reboot, the UI sits silently until the backend responds or connection drops.
After: After confirming a reboot, the UI immediately shows "Rebooting ESP..." at the bottom of the screen.

♿ Accessibility
Improves system status visibility, satisfying WCAG guidelines for predictable behavior and providing immediate textual feedback for screen reader and visual users alike (the alert container already has `role="alert"` and `aria-live="assertive"`).

---
*PR created automatically by Jules for task [9445194248847774350](https://jules.google.com/task/9445194248847774350) started by @ManupaKDU*