### PR TITLE
🎨 Palette: [UX improvement] Improve UX for long running actions and fix overlapping alerts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -117,3 +117,7 @@
 ## 2025-02-20 - Add async loading and empty states to Log viewer
 **Learning:** For components that fetch data asynchronously (like logs), users may mistake an empty or slow-to-load container for a broken feature if there's no visual feedback.
 **Action:** Always provide explicit "Loading..." and "Empty" states to clearly communicate application status during asynchronous fetches.
+## 2024-05-19 - Improved long-running action feedback and fixed alert overlap
+
+**Learning:** When using asynchronous `await sleep()` within a global notification function like `showAlert`, concurrent triggers can cause timers to overlap, resulting in one alert prematurely clearing the text of another. Additionally, removing double-confirm prompts relies on ensuring the initial call handles the explicit intent correctly before moving to backend commands or visual feedback.
+**Action:** Always use `setTimeout` with a tracked handle (e.g., `alertTimer`) to `clearTimeout` on subsequent calls for global UI notifications, ensuring only the most recent alert controls the disappearing act. When adding feedback to long-running actions, place the alert immediately before dispatching the actual backend request to provide instant confirmation.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -1212,14 +1212,11 @@
           else if (key == "AtakePhotos") { if (fromUser) wsAuxSend("G1", wsInd); }
           else if (key == "BabortPhotos") { if (fromUser) wsAuxSend("G0", wsInd); }
           else if (key == "AuxIP") return; // ignored
-          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; }
-          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; }
-          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; }
-          else if (key == 'save') await sleep(600); // allow last input to debounce
+          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; showAlert("Rebooting ESP..."); }
+          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; showAlert("Clearing NVS..."); }
+          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; showAlert("Reloading /data..."); }
+          else if (key == 'save') { await sleep(600); showAlert("Saving settings..."); } // allow last input to debounce
           if (fromUser && !$('#'+key).classList.contains("local")) {
-            if (key == "clear" && !confirm("Are you sure you want to clear NVS?")) return;
-            if (key == "deldata" && !confirm("Are you sure you want to reload /data?")) return;
-            if (key == "reset" && !confirm("Are you sure you want to reboot the ESP?")) return;
             debounceSendControl(key, value);
           }
         }

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1867,14 +1867,11 @@
           else if (key == "servoTiltPin") { value > 0 ? enableRangeSlider($('#camTilt')) : disableRangeSlider($('#camTilt')); }
           else if (key == "micSdPin") micState(value);
           else if (key == "mampSdIo") spkrState(value);
-          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; }
-          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; }
-          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; }
-          else if (key == 'save') await sleep(600); // allow last input to debounce
+          else if (key == "reset") { if (fromUser && !window.confirm("Are you sure you want to reboot the ESP?")) return; showAlert("Rebooting ESP..."); }
+          else if (key == "clear") { if (fromUser && !window.confirm("This will clear the NVS configuration. Are you sure?")) return; showAlert("Clearing NVS..."); }
+          else if (key == "deldata") { if (fromUser && !window.confirm("This will reload /data folder. Are you sure?")) return; showAlert("Reloading /data..."); }
+          else if (key == 'save') { await sleep(600); showAlert("Saving settings..."); } // allow last input to debounce
           if (fromUser && !$('#'+key).classList.contains("local")) {
-            if (key == "clear" && !confirm("Are you sure you want to clear NVS?")) return;
-            if (key == "deldata" && !confirm("Are you sure you want to reload /data?")) return;
-            if (key == "reset" && !confirm("Are you sure you want to reboot the ESP?")) return;
             debounceSendControl(key, value);
           }
         }

--- a/data/common.js
+++ b/data/common.js
@@ -503,10 +503,13 @@
           return (typeof variable === 'undefined' || variable === null ) ? false : true;
         }
 
+        let alertTimer = null;
         async function showAlert(value) {
           $('#alertText').innerHTML = value;
-          await sleep(5000);
-          $('#alertText').innerHTML = "";
+          if (alertTimer) clearTimeout(alertTimer);
+          alertTimer = setTimeout(() => {
+            $('#alertText').innerHTML = "";
+          }, 5000);
         }
 
         async function saveChanges(resetMsg = "User requested restart") {


### PR DESCRIPTION
This PR improves the UX around long running operations such as Resetting the ESP, Clearing NVS, Reloading data, and Saving settings.

💡 What:
Added instant visual feedback via toast alerts (`showAlert`) immediately before backend commands are dispatched for long-running actions. Fixed the `showAlert` function in `data/common.js` to use `setTimeout` with a tracked handle, preventing concurrent alerts from clearing each other prematurely. Removed redundant second `confirm()` checks for destructive actions that caused double prompting.

🎯 Why:
Users previously lacked immediate visual feedback when triggering long-running actions like "Reboot ESP" or "Clear NVS", making the interface feel unresponsive. The redundant `confirm()` checks were annoying, and the `showAlert` timeout bug caused important notifications to disappear too quickly if triggered sequentially.

📸 Before/After:
Before: Clicking "Reboot ESP" resulted in a double confirmation prompt, followed by a silent delay while the device rebooted. If multiple alerts fired, they cleared each other out unpredictably.
After: Clicking "Reboot ESP" presents a single confirmation prompt, immediately followed by a "Rebooting ESP..." toast alert. Alerts display reliably for their full duration.

♿ Accessibility:
The instant visual feedback (toast alerts) ensures that screen readers and visual users alike are immediately informed of the system's state change, improving overall clarity.

---
*PR created automatically by Jules for task [4765992277421613393](https://jules.google.com/task/4765992277421613393) started by @ManupaKDU*