### PR TITLE
🧹 [code health] Remove dead ping profile code in utils.cpp

### DIFF
--- a/utils.cpp
+++ b/utils.cpp
@@ -436,8 +436,6 @@ static void statusCheck() {
 }
 
 static void pingSuccess(esp_ping_handle_t hdl, void *args) {
-  //uint32_t elapsed_time;
-  //esp_ping_get_profile(hdl, ESP_PING_PROF_TIMEGAP, &elapsed_time, sizeof(elapsed_time));
   if (DEBUG_MEM) {
     static uint32_t minStack = UINT32_MAX;
     uint32_t freeStack = (uint32_t)uxTaskGetStackHighWaterMark(NULL);


### PR DESCRIPTION
🎯 **What:** Removed unused, commented-out `esp_ping_get_profile` and `elapsed_time` declarations in `utils.cpp` inside `pingSuccess`.
💡 **Why:** Cleaning up dead code improves maintainability and overall code readability without changing any behavior.
✅ **Verification:** Verified by dynamically testing via `python test_playwright.py` and `test_mock.cpp`, and ensuring no runtime logic regressions. Statically verified with grep.
✨ **Result:** A cleaner `utils.cpp` without obsolete commented code.

---
*PR created automatically by Jules for task [18064349972356929442](https://jules.google.com/task/18064349972356929442) started by @ManupaKDU*