### PR TITLE
🧹 Remove unused commented debug code in mqtt.cpp

### DIFF
--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -118,9 +118,6 @@ static void mqtt_error_handler(void *handler_args, esp_event_base_t base, int32_
   esp_mqtt_event_handle_t event = (esp_mqtt_event_handle_t)event_data;
   LOG_VRB("Mqtt event error %i", event->msg_id);    
   if (event->error_handle->error_type == MQTT_ERROR_TYPE_TCP_TRANSPORT) {
-    // log_error_if_nonzero("reported from esp-tls", event->error_handle->esp_tls_last_esp_err);
-    // log_error_if_nonzero("reported from tls stack", event->error_handle->esp_tls_stack_err);
-    // log_error_if_nonzero("captured as transport's socket errno", event->error_handle->esp_transport_sock_errno);
     LOG_WRN("Last err string (%s)", strerror(event->error_handle->esp_transport_sock_errno));
     mqttConnected = false;
   }


### PR DESCRIPTION
🎯 **What:** Removed commented-out debug code in `mqtt.cpp` from the `mqtt_error_handler` function.
💡 **Why:** To improve code maintainability and readability by cleaning up unused, dead code.
✅ **Verification:** Visually inspected the code changes using `git diff` to ensure that only the unused, commented code was removed. Attempted to run Playwright tests, which were unaffected by this backend code modification.
✨ **Result:** A cleaner `mqtt.cpp` file without stale debugging comments.

---
*PR created automatically by Jules for task [10825313069595479810](https://jules.google.com/task/10825313069595479810) started by @ManupaKDU*