### PR TITLE
🧹 [code health improvement] Remove commented-out dead code showConfigVect

### DIFF
--- a/prefs.cpp
+++ b/prefs.cpp
@@ -49,13 +49,6 @@ static bool getNextKeyVal() {
   return false;
 }
 
-void showConfigVect() {
-  for (const std::vector<std::string>& innerVector : configs) {
-    // Print each element of the inner vector
-    for (const std::string& element : innerVector) printf("%s,", element.c_str());
-    printf("\n"); // Add a newline after each inner vector
-  }
-}
 
 void reloadConfigs() {
   while (getNextKeyVal()) updateStatus(variable, value, false);
@@ -571,7 +564,6 @@ bool loadConfig() {
   if (!res) res = checkConfigFile(); // to recreate file if deleted on first call
   if (res) {
     loadConfigVect();
-    //showConfigVect();
     loadPrefs(); // overwrites any corresponding entries in config
     // load variables from stored config vector
     reloadConfigs();


### PR DESCRIPTION
🎯 **What:** Removed the commented-out `//showConfigVect();` call at `prefs.cpp:574` and completely deleted the associated unused function definition at `prefs.cpp:52-58`.
💡 **Why:** Eliminating dead code and commented-out debugging lines improves codebase clarity, reduces clutter, and ensures developers aren't distracted by unused functionality, enhancing overall maintainability.
✅ **Verification:** Created a standalone mock C++ test replicating the dependencies of the removed code, compiled it, and confirmed it executed successfully. Verified the diff using `git diff` to ensure no active code was affected.
✨ **Result:** A cleaner `prefs.cpp` file without extraneous debug logic, improving readability while preserving identical functionality.

---
*PR created automatically by Jules for task [4741998981770079390](https://jules.google.com/task/4741998981770079390) started by @ManupaKDU*