### PR TITLE
🧹 Remove unused debug code in periphsI2C.cpp

### DIFF
--- a/periphsI2C.cpp
+++ b/periphsI2C.cpp
@@ -902,13 +902,6 @@ void lcdAutoScroll(bool autoScroll) {
 
 void lcdLoadCustom(uint8_t charLoc, uint8_t charmap[]) {
   // Load custom character
-  // To create, see https://maxpromer.github.io/LCD-Character-Creator/
-  // array of 8 lines of 5 bits, where bits represent pixel on / off
-  // eg define & load custom char (degrees celsius symbol)
-  // uint8_t celsius[] = {B01000, B10100, B01011, B00100, B00100, B00100, B00011, B00000};
-  // enum customChar {CELSIUS, CC1, CC2, CC3, CC4, CC5, CC6, CC7};
-  // lcdLoadCustom(CELSIUS, celsius);
-  // lcdWriteCustom(CELSIUS);
   if (charLoc > 7) LOG_WRN("custom char number %u out of range", charLoc);
   else {
   	charLoc &= 0x7; // CGRAM location to load 0 - 7


### PR DESCRIPTION
🎯 **What:** Removed commented-out debug code related to custom LCD character creation in `lcdLoadCustom` within `periphsI2C.cpp`.

💡 **Why:** The commented-out code blocks (URLs, arrays, and function calls) represent dead code. Removing them reduces clutter and improves the overall maintainability and readability of the source file.

✅ **Verification:** Verified via `git diff` and compilation that the removal was clean and no regressions were introduced to the remaining code. Successfully ran the existing C++ and python test suites (`test_mock.cpp` and `test_playwright.py`).

✨ **Result:** The codebase is cleaner and easier to read without changing any functionality.

---
*PR created automatically by Jules for task [3077631062194623036](https://jules.google.com/task/3077631062194623036) started by @ManupaKDU*