### PR TITLE
🧹 Remove unused commented-out HTTP daemon match functions

### DIFF
--- a/webServer.cpp
+++ b/webServer.cpp
@@ -642,7 +642,6 @@ bool startWebServer() {
     config.httpd.max_uri_handlers = MAX_HANDLERS;
     config.httpd.max_open_sockets = HTTP_CLIENTS + MAX_STREAMS;
     config.httpd.task_priority = HTTP_PRI;
-    //config.httpd.uri_match_fn = httpd_uri_match_wildcard;
     res = httpd_ssl_start(&httpServer, &config);
   } else {
 #else
@@ -658,7 +657,6 @@ bool startWebServer() {
     config.max_uri_handlers = MAX_HANDLERS;
     config.max_open_sockets = HTTP_CLIENTS + MAX_STREAMS;
     config.task_priority = HTTP_PRI;
-    //config.uri_match_fn = httpd_uri_match_wildcard;
     res = httpd_start(&httpServer, &config);
   }
   httpd_uri_t indexUri = {.uri = "/", .method = HTTP_GET, .handler = indexHandler, .user_ctx = NULL};


### PR DESCRIPTION
🎯 **What:** Removed two instances of unused, commented-out HTTP daemon match configuration lines (`uri_match_fn = httpd_uri_match_wildcard`) in `webServer.cpp`.
💡 **Why:** Dead, commented-out code clutters the file and serves no purpose. Removing it improves the readability and maintainability of the web server initialization block.
✅ **Verification:** Verified via `git diff` that only the two commented lines were removed, maintaining the structural integrity of the function. Compiled and successfully ran the host-side unit test suite (`test_mock`) to guarantee no regressions were introduced.
✨ **Result:** A cleaner `webServer.cpp` file without confusing dead code.

---
*PR created automatically by Jules for task [14921949628855491690](https://jules.google.com/task/14921949628855491690) started by @ManupaKDU*