### PR TITLE
🔒 Fix buffer overflow vulnerability in WebDAV handlers

### DIFF
--- a/webDav.cpp
+++ b/webDav.cpp
@@ -196,7 +196,8 @@ static bool handleGet() {
     return false;
   } else {
     httpd_resp_set_type(req, mimeTypes[getMimeType(pathName)]);
-    strcpy(inFileName, pathName);
+    strncpy(inFileName, pathName, IN_FILE_NAME_LEN - 1);
+    inFileName[IN_FILE_NAME_LEN - 1] = '\0';
     esp_err_t res = fileHandler(req); // file content
     return res == ESP_OK ? true : false;
   }
@@ -239,7 +240,8 @@ static bool handlePut() {
   }
   if (req->content_len) {
     // transfer file content to SD
-    strcpy(inFileName, pathName);
+    strncpy(inFileName, pathName, IN_FILE_NAME_LEN - 1);
+    inFileName[IN_FILE_NAME_LEN - 1] = '\0';
     esp_err_t res = uploadHandler(req);
     return res == ESP_OK ? true : false;
   }


### PR DESCRIPTION
🎯 **What:** 
Fixed a potential buffer overflow vulnerability in the WebDAV GET (`handleGet`) and PUT (`handlePut`) handlers.

⚠️ **Risk:** 
The use of `strcpy` to copy `pathName` into the fixed-size `inFileName` buffer could lead to a buffer overflow if a maliciously crafted or overly long path name was provided. This could potentially allow an attacker to overwrite adjacent memory, leading to a crash (Denial of Service) or arbitrary code execution.

🛡️ **Solution:** 
Replaced the unsafe `strcpy(inFileName, pathName);` calls with `strncpy(inFileName, pathName, IN_FILE_NAME_LEN - 1);` and ensured explicit null-termination (`inFileName[IN_FILE_NAME_LEN - 1] = '\0';`). This guarantees that the copy operation will never exceed the defined boundaries of `inFileName`.

---
*PR created automatically by Jules for task [9329385320352383615](https://jules.google.com/task/9329385320352383615) started by @ManupaKDU*