### PR TITLE
🧹 Type mismatch in format string

### DIFF
--- a/mjpeg2sd.cpp
+++ b/mjpeg2sd.cpp
@@ -178,20 +178,20 @@ static void timeLapse(camera_fb_t* fb, bool tlStop = false) {
         // initialise time lapse avi
         requiredFrames = tlDurationMins * 60 / tlSecsBetweenFrames;
         if (requiredFrames > maxFrames) {
-          LOG_WRN("Frames required for timelapse %u reduced to max frame limit %u", requiredFrames, maxFrames);
+          LOG_WRN("Frames required for timelapse %d reduced to max frame limit %d", requiredFrames, maxFrames);
           requiredFrames = maxFrames;
         }
         dateFormat(partName, sizeof(partName), true);
         STORAGE.mkdir(partName); // make date folder if not present
         dateFormat(partName, sizeof(partName), false);
-        int tlen = snprintf(TLname, FILE_NAME_LEN - 1, "%s_%s_%u_%u_T.%s",
+        int tlen = snprintf(TLname, FILE_NAME_LEN - 1, "%s_%s_%d_%d_T.%s",
                             partName, frameData[fsizePtr].frameSizeStr, tlPlaybackFPS, tlDurationMins, AVI_EXT);
         if (tlen > FILE_NAME_LEN - 1) LOG_WRN("file name truncated");
         if (STORAGE.exists(TLTEMP)) STORAGE.remove(TLTEMP);
         tlFile = STORAGE.open(TLTEMP, FILE_WRITE);
         tlFile.write(aviHeader, AVI_HEADER_LEN); // space for header
         prepAviIndex(true);
-        LOG_INF("Started time lapse file %s, duration %u mins, for %u frames",  TLname, tlDurationMins, requiredFrames);
+        LOG_INF("Started time lapse file %s, duration %d mins, for %d frames",  TLname, tlDurationMins, requiredFrames);
         frameCntTL++; // to stop re-entering
       }
       // switch on light before capture frame if nightTime


### PR DESCRIPTION
🎯 **What:** Fixed type mismatch in format string specifiers in `mjpeg2sd.cpp` (lines 181, 187, 194) where `%u` was incorrectly used for integer variables (`requiredFrames`, `maxFrames`, `tlPlaybackFPS`, `tlDurationMins`). Changed to `%d`.
💡 **Why:** Fixes compiler warnings and prevents potential undefined behavior or runtime issues due to incorrect type conversions when handling integer representations.
✅ **Verification:** Verified changes via `git diff` and ran the test suite using `g++ -o test_mock_bin test_mock.cpp && ./test_mock_bin`. The tests pass and no functionality is altered.
✨ **Result:** Improved code health and safety.

---
*PR created automatically by Jules for task [15270669515057929876](https://jules.google.com/task/15270669515057929876) started by @ManupaKDU*