### PR TITLE
🧹 Fix format string type mismatches for size_t

### DIFF
--- a/appSpecific.cpp
+++ b/appSpecific.cpp
@@ -345,7 +345,7 @@ esp_err_t appSpecificWebHandler(httpd_req_t *req, const char* variable, const ch
       httpd_resp_set_hdr(req, "Content-Disposition", "inline; filename=capture.jpg");
       httpd_resp_send(req, (const char*)alertBuffer, alertBufferSize);
       uint32_t jpegTime = millis() - startTime;
-      LOG_INF("JPEG: %uB in %ums", alertBufferSize, jpegTime);
+      LOG_INF("JPEG: %zuB in %ums", alertBufferSize, jpegTime);
       alertBufferSize = 0;
     } else LOG_WRN("Failed to get still");
   }

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -130,7 +130,7 @@ void sendMqttImage(){
   if (!doKeepFrame && alertBufferSize) {
      const char* picBuff = (const char*)(alertBuffer);
      int id = esp_mqtt_client_publish(mqtt_client, image_topic, picBuff, alertBufferSize, MQTT_QOS, 0);
-     LOG_VRB("Sent pic, size: %u", alertBufferSize);
+     LOG_VRB("Sent pic, size: %zu", alertBufferSize);
   }else{
     LOG_WRN("Fail to send image");
   }


### PR DESCRIPTION
🎯 **What:** Fixed type mismatches in format strings where `alertBufferSize` (type `size_t`) was formatted with `%u` instead of `%zu` in `appSpecific.cpp` and `mqtt.cpp`.

💡 **Why:** `size_t` types require the `%zu` format specifier. Using `%u` can lead to compiler warnings, incorrect logging, and potential undefined behavior on systems where the size of `size_t` differs from `unsigned int`.

✅ **Verification:** Verified changes visually with `git diff`. Ran the C++ test suite (`test_mock.cpp`) locally which compiled correctly with the changes and all path traversal tests passed.

✨ **Result:** Cleaned up compiler warnings and ensured correct, type-safe logging behavior for buffer sizes.

---
*PR created automatically by Jules for task [10649215266853110259](https://jules.google.com/task/10649215266853110259) started by @ManupaKDU*