### PR TITLE
🔒 Fix buffer overflow in extractMeta

### DIFF
--- a/mjpeg2sd.cpp
+++ b/mjpeg2sd.cpp
@@ -544,7 +544,8 @@ static fnameStruct extractMeta(const char* fname) {
   // extract FPS, duration, and frame count from avi filename
   fnameStruct fnameMeta = {0, 0, 0};
   char fnameStr[FILE_NAME_LEN];
-  strcpy(fnameStr, fname);
+  strncpy(fnameStr, fname, sizeof(fnameStr) - 1);
+  fnameStr[sizeof(fnameStr) - 1] = '\0';
   // replace all '_' with space for sscanf
   replaceChar(fnameStr, '_', ' ');
   int items = sscanf(fnameStr, "%*s %*s %*s %hhu %lu", &fnameMeta.recFPS, &fnameMeta.recDuration);


### PR DESCRIPTION
🎯 **What:** Fixed a potential buffer overflow vulnerability in `extractMeta` inside `mjpeg2sd.cpp` where `strcpy` was used without bounds checking.
⚠️ **Risk:** A maliciously crafted or excessively long filename could overflow the fixed-size `fnameStr` buffer (`FILE_NAME_LEN`), potentially leading to memory corruption or arbitrary code execution.
🛡️ **Solution:** Replaced `strcpy` with `strncpy`, bound to the allocated size of the array minus one, and explicitly null-terminated the resulting string to ensure memory safety.

---
*PR created automatically by Jules for task [913551548916100221](https://jules.google.com/task/913551548916100221) started by @ManupaKDU*