### PR TITLE
🧹 Fix format string type mismatch in appSpecific.cpp

### DIFF
--- a/appSpecific.cpp
+++ b/appSpecific.cpp
@@ -673,7 +673,7 @@ void getNocturnal() {
       remoteServerClose(hclient);
     }
   }
-  if (deepSleepTimer) LOG_INF("Night time duration: %lu secs at Lat: %0.6f, Lon: %0.6f", deepSleepTimer, latLon[0], latLon[1]);
+  if (deepSleepTimer) LOG_INF("Night time duration: %u secs at Lat: %0.6f, Lon: %0.6f", deepSleepTimer, latLon[0], latLon[1]);
 }
 
 void doAppPing(bool timeSynced) {


### PR DESCRIPTION
🎯 **What:** Changed the format specifier for `deepSleepTimer` (which is a `uint32_t`) from `%lu` to `%u` in `LOG_INF` call.
💡 **Why:** `uint32_t` is typedef'd as `unsigned int` on this platform, so `%lu` expects `unsigned long` and triggers type mismatch warnings. Changing it to `%u` prevents potential runtime issues and resolves compiler warnings.
✅ **Verification:** Compiled test binaries, visually inspected the git diff to ensure only the target line was modified, and verified that build artifacts were removed.
✨ **Result:** Improved codebase maintainability by fixing a subtle type mismatch that produces a compiler warning.

---
*PR created automatically by Jules for task [8314518478209457590](https://jules.google.com/task/8314518478209457590) started by @ManupaKDU*