### PR TITLE
🧹 [Code Health] Fix type mismatch in format string

### DIFF
--- a/mjpeg2sd.cpp
+++ b/mjpeg2sd.cpp
@@ -116,7 +116,7 @@ void controlFrameTimer(bool restartTimer) {
     frameTimer = timerBegin(OneMHz);
     if (frameTimer) {
       frameInterval = OneMHz / FPS; // in units of us
-      LOG_VRB("Frame timer interval %lums for FPS %u", frameInterval / 1000, FPS);
+      LOG_VRB("Frame timer interval %lums for FPS %u", (unsigned long)(frameInterval / 1000), FPS);
       timerAttachInterrupt(frameTimer, &frameISR);
       timerAlarm(frameTimer, frameInterval, true, 0); // micro seconds
     } else LOG_ERR("Failed to setup frameTimer");


### PR DESCRIPTION
🎯 **What:** Fixed a type mismatch in a format string within `mjpeg2sd.cpp` where `frameInterval / 1000` (an `unsigned int`/`uint32_t`) was passed to a `%lums` format specifier. It is now explicitly cast to `unsigned long`.
💡 **Why:** This directly addresses compiler warnings about type mismatches between format strings and argument types, preventing potential undefined behavior or runtime formatting issues, and making the code more robust.
✅ **Verification:** Verified the fix by ensuring the local C++ test suite passes without regressions. 
✨ **Result:** A safer, correctly formatted logging statement.

---
*PR created automatically by Jules for task [13742543626909060264](https://jules.google.com/task/13742543626909060264) started by @ManupaKDU*