### PR TITLE
🧹 Fix type mismatch in format string

### DIFF
--- a/appSpecific.cpp
+++ b/appSpecific.cpp
@@ -308,7 +308,7 @@ static bool extractKeyVal(const char* wsMsg) {
     strncpy(value, endPtr + 1, FILE_NAME_LEN - 1); // value is now second part of string
     value[FILE_NAME_LEN - 1] = 0; // ensure null termination
     return true;
-  } else LOG_ERR("Invalid query string: %s", wsMsg);
+  } else LOG_ERR("Invalid query string: %s", (char*)wsMsg);
   return false;
 }
 


### PR DESCRIPTION
🎯 **What:** Added an explicit `(char*)` cast to `wsMsg` on line 311 of `appSpecific.cpp` when calling `LOG_ERR`.

💡 **Why:** `wsMsg` is defined as `const char*` and passed to a logging macro using the `%s` format specifier, which can trigger strict `-Wformat` compiler warnings. Casting it to `(char*)` resolves the mismatch and improves code health by silencing the warning without mutating the underlying buffer.

✅ **Verification:** Verified the fix cleanly addresses the issue by locally checking `git diff` and running the existing C++ and Python test suites (`test_mock_bin`, `python test_playwright.py`) to ensure no regressions were introduced.

✨ **Result:** The compiler format string type mismatch warning is resolved, leading to cleaner compilation and improved code maintainability without affecting runtime behavior.

---
*PR created automatically by Jules for task [18260803917368925315](https://jules.google.com/task/18260803917368925315) started by @ManupaKDU*