### PR TITLE
🔒 Fix buffer overflow risk in getFolderName

### DIFF
--- a/ftp.cpp
+++ b/ftp.cpp
@@ -277,7 +277,8 @@ static bool ftpStoreFile(File &fh) {
 
 static bool getFolderName(const char* folderName) {
   // extract folder names from path name
-  strcpy(folderPath, folderName); 
+  strncpy(folderPath, folderName, sizeof(folderPath) - 1);
+  folderPath[sizeof(folderPath) - 1] = '\0';
   int pos = 1; // skip 1st '/'
   // get each folder name in sequence
   bool res = true;


### PR DESCRIPTION
### 🎯 What
Fixed a buffer overflow vulnerability in `ftp.cpp`'s `getFolderName` function. The function was using an unsafe `strcpy` to copy an arbitrarily sized `folderName` into a fixed-size local static buffer `folderPath`.

### ⚠️ Risk
If a malicious or overly long folder name was provided, it would overflow the `folderPath` buffer, potentially overwriting adjacent memory, causing a crash (Denial of Service), or theoretically allowing for arbitrary code execution.

### 🛡️ Solution
Replaced the `strcpy` call with a bounds-checked `strncpy`, explicitly limiting the copy to `sizeof(folderPath) - 1`. Added an explicit null-terminator assignment (`folderPath[sizeof(folderPath) - 1] = '\0'`) to ensure the resulting string is safely terminated even if truncation occurred.

---
*PR created automatically by Jules for task [16948486392074552796](https://jules.google.com/task/16948486392074552796) started by @ManupaKDU*