### PR TITLE
🧹 Fix format string type mismatches in mjpeg2sd.cpp

### DIFF
--- a/mjpeg2sd.cpp
+++ b/mjpeg2sd.cpp
@@ -178,20 +178,20 @@ static void timeLapse(camera_fb_t* fb, bool tlStop = false) {
         // initialise time lapse avi
         requiredFrames = tlDurationMins * 60 / tlSecsBetweenFrames;
         if (requiredFrames > maxFrames) {
-          LOG_WRN("Frames required for timelapse %u reduced to max frame limit %u", requiredFrames, maxFrames);
+          LOG_WRN("Frames required for timelapse %d reduced to max frame limit %d", requiredFrames, maxFrames);
           requiredFrames = maxFrames;
         }
         dateFormat(partName, sizeof(partName), true);
         STORAGE.mkdir(partName); // make date folder if not present
         dateFormat(partName, sizeof(partName), false);
-        int tlen = snprintf(TLname, FILE_NAME_LEN - 1, "%s_%s_%u_%u_T.%s",
+        int tlen = snprintf(TLname, FILE_NAME_LEN - 1, "%s_%s_%d_%d_T.%s",
                             partName, frameData[fsizePtr].frameSizeStr, tlPlaybackFPS, tlDurationMins, AVI_EXT);
         if (tlen > FILE_NAME_LEN - 1) LOG_WRN("file name truncated");
         if (STORAGE.exists(TLTEMP)) STORAGE.remove(TLTEMP);
         tlFile = STORAGE.open(TLTEMP, FILE_WRITE);
         tlFile.write(aviHeader, AVI_HEADER_LEN); // space for header
         prepAviIndex(true);
-        LOG_INF("Started time lapse file %s, duration %u mins, for %u frames",  TLname, tlDurationMins, requiredFrames);
+        LOG_INF("Started time lapse file %s, duration %d mins, for %d frames",  TLname, tlDurationMins, requiredFrames);
         frameCntTL++; // to stop re-entering
       }
       // switch on light before capture frame if nightTime


### PR DESCRIPTION
🎯 **What:** Fixed type mismatches in format strings where signed integers (`int`) were being formatted with `%u` (unsigned) specifiers.
💡 **Why:** Formatting signed variables with `%u` can cause compiler warnings (like `-Wformat`) and potential runtime output issues if the values were ever negative or interpreted incorrectly. Updating the format specifiers to `%d` aligns them with their underlying variable types (`requiredFrames`, `maxFrames`, `tlDurationMins`, `tlPlaybackFPS`), improving code health.
✅ **Verification:** Verified by compiling the repository test suite (`g++ -o test_mock_bin test_mock.cpp && ./test_mock_bin`), ensuring that all tests pass, and visually confirming the git diff accurately targeted the issue without disrupting application logic. The temporary binary was removed to ensure it was not staged.
✨ **Result:** Cleaned up code health issues, preventing unexpected formatting and suppressing compiler warnings for the affected logging and string generation routines.

---
*PR created automatically by Jules for task [13482276672402777230](https://jules.google.com/task/13482276672402777230) started by @ManupaKDU*