### PR TITLE
🔒 Fix potential buffer overflow in WebDAV GET/PUT handlers

### DIFF
--- a/webDav.cpp
+++ b/webDav.cpp
@@ -196,7 +196,8 @@ static bool handleGet() {
     return false;
   } else {
     httpd_resp_set_type(req, mimeTypes[getMimeType(pathName)]);
-    strcpy(inFileName, pathName);
+    strncpy(inFileName, pathName, IN_FILE_NAME_LEN - 1);
+    inFileName[IN_FILE_NAME_LEN - 1] = '\0';
     esp_err_t res = fileHandler(req); // file content
     return res == ESP_OK ? true : false;
   }
@@ -239,7 +240,8 @@ static bool handlePut() {
   }
   if (req->content_len) {
     // transfer file content to SD
-    strcpy(inFileName, pathName);
+    strncpy(inFileName, pathName, IN_FILE_NAME_LEN - 1);
+    inFileName[IN_FILE_NAME_LEN - 1] = '\0';
     esp_err_t res = uploadHandler(req);
     return res == ESP_OK ? true : false;
   }


### PR DESCRIPTION
🎯 **What:** 
Fixed a potential stack-based buffer overflow in the `handlePut` and `handleGet` functions of `webDav.cpp`. The code was directly copying user-provided strings (`pathName`) into a static buffer (`inFileName`) using `strcpy`.

⚠️ **Risk:** 
If an attacker provides a `pathName` that exceeds `IN_FILE_NAME_LEN`, the `strcpy` operation will write past the end of the `inFileName` array. This leads to a classic buffer overflow which could potentially corrupt memory, cause a denial of service (reboot), or, under specific conditions, allow for arbitrary code execution depending on what memory gets overwritten.

🛡️ **Solution:** 
Replaced the unbounded `strcpy(inFileName, pathName)` calls with safer, bounded `strncpy(inFileName, pathName, IN_FILE_NAME_LEN - 1)` calls. Additionally, explicitly null-terminated the `inFileName` buffer at `IN_FILE_NAME_LEN - 1` to ensure it always remains a valid C string even if truncation occurs.

---
*PR created automatically by Jules for task [17885568892812876587](https://jules.google.com/task/17885568892812876587) started by @ManupaKDU*