### PR TITLE
🔒 Fix Buffer Overflow During SD Playback

### DIFF
--- a/mjpeg2sd.cpp
+++ b/mjpeg2sd.cpp
@@ -583,7 +583,8 @@ void openSDfile(const char* streamFile) {
   if (stopPlayback) LOG_WRN("Playback refused - capture in progress");
   else {
     stopPlaying(); // in case already running
-    strcpy(aviFileName, streamFile);
+    strncpy(aviFileName, streamFile, FILE_NAME_LEN - 1);
+    aviFileName[FILE_NAME_LEN - 1] = '\0';
     LOG_INF("Playing %s", aviFileName);
     playbackFile = STORAGE.open(aviFileName, FILE_READ);
     playbackFile.seek(AVI_HEADER_LEN, SeekSet); // skip over header


### PR DESCRIPTION
🎯 **What:** Replace `strcpy` with `strncpy` to prevent buffer overflow in `aviFileName`.
⚠️ **Risk:** A malicious or overly long filename could overflow the 64-byte `aviFileName` buffer on the stack/BSS, leading to arbitrary code execution, crash, or memory corruption.
🛡️ **Solution:** Bound the string copy to `FILE_NAME_LEN - 1` and ensure null-termination.

---
*PR created automatically by Jules for task [822700606106105468](https://jules.google.com/task/822700606106105468) started by @ManupaKDU*