### PR TITLE
🧹 [Code Health] Fix type mismatch in mjpeg2sd.cpp format string

### DIFF
--- a/mjpeg2sd.cpp
+++ b/mjpeg2sd.cpp
@@ -135,7 +135,7 @@ static void openAvi() {
   // open avi file with temporary name
   aviFile = STORAGE.open(AVITEMP, FILE_WRITE);
   oTime = millis() - oTime;
-  LOG_VRB("File opening time: %lums", oTime);
+  LOG_VRB("File opening time: %ums", oTime);
 #if INCLUDE_AUDIO
   startAudioRecord();
 #endif


### PR DESCRIPTION
### 🎯 What
Fixed a format string mismatch in `mjpeg2sd.cpp` (specifically `LOG_VRB("File opening time: %lums", oTime);`) by updating the format specifier to `%ums`. `oTime` is declared as `static uint32_t`, which on ESP32 translates to `unsigned int`, making `%u` the correct format specifier.

### 💡 Why
Using `%lu` to format a `uint32_t` (`unsigned int`) value results in type mismatch compiler warnings and theoretically undefined behavior on certain architectures. Fixing this improves the overall code health, maintains strict type safety, and silences compiler warnings during build processes.

### ✅ Verification
1. Visually confirmed the fix using `git diff`.
2. Re-compiled and ran the C++ unit tests (`test_mock.cpp`) successfully.
3. Executed the Playwright test suite (`test_playwright.py`) successfully, verifying no regressions were introduced.
4. The automated code reviewer assessed the changes, acknowledging the safe and localized nature of the fix, resolving the explicit issue described.

### ✨ Result
The codebase is cleaner, with one fewer potential compiler warning. The `LOG_VRB` macro correctly logs the `oTime` without type casting or mismatch warnings, improving the overall reliability and maintainability of the project.

---
*PR created automatically by Jules for task [8769768368068625071](https://jules.google.com/task/8769768368068625071) started by @ManupaKDU*