### PR TITLE
⚡ Bolt: Optimize strlen calls in WebDAV and WebServer handlers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -91,3 +91,6 @@
 ## 2024-06-19 - Non-blocking servo sweeps
 **Learning:** The servo control task blocked the RTOS task thread while sweeping due to `delay()` inside a loop. This prevented the task from processing new pan/tilt notifications instantly and forced sequential panning.
 **Action:** Replaced the loop with stateful non-blocking time checks using `millis()` and computed an appropriate `waitTicks` dynamically to use with `ulTaskNotifyTake`. This completely decoupled the sweeps from task execution, halving benchmark sweep time by allowing concurrent sweeps.
+## 2024-06-24 - [Optimize strlen on string literals and identical strings]
+**Learning:** Calling `strlen` on string literal macros (like `WEBDAV`) forces potential O(N) runtime evaluation instead of compile-time constants. Additionally, repeatedly calling `strlen` on the same dynamic string without modifying it causes redundant O(N) traversals.
+**Action:** When evaluating the length of string literals or macros, use `sizeof(MACRO) - 1` instead of `strlen`. When evaluating the length of the same dynamic string multiple times in a function block, cache the length into a variable (e.g., `size_t pathLen = strlen(pathName);`).

--- a/webDav.cpp
+++ b/webDav.cpp
@@ -297,7 +297,7 @@ static bool handleMove() {
       httpd_resp_send_404(req);
       return false;
     }
-    memmove(dest, pos + strlen(WEBDAV), strlen(pos + strlen(WEBDAV)) + 1);
+    memmove(dest, pos + (sizeof(WEBDAV) - 1), strlen(pos + (sizeof(WEBDAV) - 1)) + 1);
 
     // only allow renaming if a folder
     if (isFolder()) res = checkSamePath(pathName, dest);
@@ -323,9 +323,13 @@ static bool handleCopy() {
 bool handleWebDav(httpd_req_t* rreq) {
   // extract method to determine which WebDAV action to take
   req = rreq;
-  snprintf(pathName, sizeof(pathName), "%s", req->uri + strlen(WEBDAV)); // strip out "/webdav"
-  if (strlen(pathName) > 0 && pathName[strlen(pathName) - 1] == '/') pathName[strlen(pathName) - 1] = 0; // remove final / if present
-  if (!strlen(pathName)) strcpy(pathName, "/"); // if pathname empty, use single /
+  snprintf(pathName, sizeof(pathName), "%s", req->uri + (sizeof(WEBDAV) - 1)); // strip out "/webdav"
+  size_t pathLen = strlen(pathName); // ⚡ Bolt optimization: Cache strlen to prevent multiple O(N) traversals
+  if (pathLen > 0 && pathName[pathLen - 1] == '/') {
+    pathName[pathLen - 1] = 0; // remove final / if present
+    pathLen--;
+  }
+  if (!pathLen) strcpy(pathName, "/"); // if pathname empty, use single /
   urlDecode(pathName);
   if (isPathTraversal(pathName)) {
     httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Path traversal not allowed");

--- a/webServer.cpp
+++ b/webServer.cpp
@@ -626,7 +626,7 @@ static void https_server_user_callback(esp_https_server_user_cb_arg_t *user_cb) 
 static esp_err_t customOrNotFoundHandler(httpd_req_t *req, httpd_err_code_t err) {
   // either handle WebDAV methods or report non existent URI
 #if INCLUDE_WEBDAV
-  if (strncmp(req->uri, WEBDAV, strlen(WEBDAV)) == 0) return handleWebDav(req) ? ESP_OK : ESP_FAIL;
+  if (strncmp(req->uri, WEBDAV, (sizeof(WEBDAV) - 1)) == 0) return handleWebDav(req) ? ESP_OK : ESP_FAIL;
 #endif
   if (req->method == HTTP_OPTIONS) return sendCrossOriginHeader(req);
   // For any other URI send 404 and close socket


### PR DESCRIPTION
### 💡 What
This PR optimizes `strlen` calls in the WebDAV handlers:
1. Replaces dynamic `strlen(WEBDAV)` calls with the compile-time equivalent `(sizeof(WEBDAV) - 1)`. `WEBDAV` is a constant string macro (`"/webdav"`).
2. Caches the result of `strlen(pathName)` into a local `pathLen` variable in `handleWebDav` to prevent multiple redundant evaluations of the same string.

### 🎯 Why
`strlen` is an O(N) operation. Evaluating the length of a constant string literal at runtime is unnecessary overhead. Similarly, evaluating the length of the same dynamic string up to four times consecutively in the same function block causes redundant string traversals.

### 📊 Impact
Reduces redundant O(N) string traversals in the critical WebDAV request handler path.

### 🔬 Measurement
Verified the logic visually and ran the C++ unit tests via `test_mock_bin` and the UI Python test suite to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [5418415666424154380](https://jules.google.com/task/5418415666424154380) started by @ManupaKDU*