### PR TITLE
⚡ Bolt: Optimize strlen on string literals and identical strings in WebDAV

### DIFF
--- a/webDav.cpp
+++ b/webDav.cpp
@@ -332,9 +332,14 @@ bool handleWebDav(httpd_req_t* rreq) {
   if (req->method == HTTP_OPTIONS) return handleOptions(); // supported options
   if (!checkAuth(req)) return false;
 
-  snprintf(pathName, sizeof(pathName), "%s", req->uri + strlen(WEBDAV)); // strip out "/webdav"
-  if (strlen(pathName) > 0 && pathName[strlen(pathName) - 1] == '/') pathName[strlen(pathName) - 1] = 0; // remove final / if present
-  if (!strlen(pathName)) strcpy(pathName, "/"); // if pathname empty, use single /
+  // ⚡ Bolt optimization: Use sizeof on literal macro and cache path length to prevent redundant O(N) traversals
+  snprintf(pathName, sizeof(pathName), "%s", req->uri + (sizeof(WEBDAV) - 1)); // strip out "/webdav"
+  size_t pathLen = strlen(pathName);
+  if (pathLen > 0 && pathName[pathLen - 1] == '/') {
+    pathName[pathLen - 1] = 0; // remove final / if present
+    pathLen--;
+  }
+  if (!pathLen) strcpy(pathName, "/"); // if pathname empty, use single /
   urlDecode(pathName);
   if (isPathTraversal(pathName)) {
     httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Path traversal not allowed");


### PR DESCRIPTION
💡 **What**: Optimized string length evaluations in `webDav.cpp`. Replaced `strlen(WEBDAV)` with compile-time `(sizeof(WEBDAV) - 1)` and cached the length of `pathName` into a local variable (`pathLen`).
🎯 **Why**: Using `strlen` on literal string macros and repeatedly calling it on the same dynamic string without caching causes redundant $O(N)$ string traversals, creating unnecessary CPU overhead on embedded devices like the ESP32.
📊 **Impact**: Reduces time complexity of string length evaluations in this block from $O(4N)$ down to $O(N)$.
🔬 **Measurement**: Verified the logic functionally behaves exactly the same via C++ test suite and Playwright UI tests. Both passed successfully.

---
*PR created automatically by Jules for task [1751354085447829007](https://jules.google.com/task/1751354085447829007) started by @ManupaKDU*