### PR TITLE
🎨 Palette: [UX improvement] Add tooltips to camera setting inputs

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1098,7 +1098,7 @@
                   </div>
                   <div class="input-group" id="aec_value-group">
                     <label for="aec_value"id="aec_value_lab">Manual Exposure</label>
-                    <input type="range" id="aec_value" min="0" max="1200" value="204">
+                    <input title="Set manual exposure value" type="range" id="aec_value" min="0" max="1200" value="204">
                   </div>
                   <div class="input-group" id="aec2-group">
                     <label for="aec2" id="aec2_lab">AEC DSP</label>
@@ -1110,7 +1110,7 @@
                   <div class="input-group hidden" id="agc_gain-group">
                     <label for="agc_gain" id="agc_gain_lab">Gain</label>
                     <div name="rangeMin">1x</div>
-                    <input type="range" id="agc_gain" min="0" max="30" value="5">
+                    <input title="Set automatic gain control limit" type="range" id="agc_gain" min="0" max="30" value="5">
                     <div name="rangeMax">31x</div>
                   </div>
                   <div class="input-group" id="hmirror-group">
@@ -1151,7 +1151,7 @@
                     </div>
                     <div class="input-group" id="ae_level-group">
                       <label for="ae_level">Exposure Level</label>
-                      <input type="range" id="ae_level" min="-2" max="2" value="0">
+                      <input title="Set automatic exposure level" type="range" id="ae_level" min="-2" max="2" value="0">
                     </div>
                     <div class="input-group" id="dcw-group">
                       <label for="dcw" id="dcw_lab">DCW (Downsize)</label>
@@ -1170,7 +1170,7 @@
                     <div class="input-group" id="gainceiling-group">
                       <label for="gainceiling">Gain Ceiling</label>
                       <div name="rangeMin">2x</div>
-                      <input type="range" id="gainceiling" min="0" max="6" value="0">
+                      <input title="Set gain ceiling limit" type="range" id="gainceiling" min="0" max="6" value="0">
                       <div name="rangeMax">128x</div>
                     </div>
                     <div class="input-group" id="lenc-group">


### PR DESCRIPTION
💡 What: Added `title` tooltip attributes to four key camera setting inputs (Manual Exposure, Gain, Exposure Level, and Gain Ceiling) in `data/MJPEG2SD.htm`.
🎯 Why: These range inputs lacked native hover tooltips, reducing discoverability. Adding `title` attributes makes it clear to users what each slider controls before they interact with it, improving the overall UX of the settings menu.
📸 Before/After: The sliders behave exactly the same, but now natively display a small browser tooltip describing their function on hover.
♿ Accessibility: The `title` attribute provides an additional layer of native accessibility for screen readers and keyboard users traversing the settings menu.

---
*PR created automatically by Jules for task [628999562494090202](https://jules.google.com/task/628999562494090202) started by @ManupaKDU*