### PR TITLE
⚡ Bolt: optimize literal length calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -94,3 +94,6 @@
 ## 2024-06-24 - [Optimize strlen on string literals and identical strings]
 **Learning:** Calling `strlen` on string literal macros (like `WEBDAV`) forces potential O(N) runtime evaluation instead of compile-time constants. Additionally, repeatedly calling `strlen` on the same dynamic string without modifying it causes redundant O(N) traversals.
 **Action:** When evaluating the length of string literals or macros, use `sizeof(MACRO) - 1` instead of `strlen`. When evaluating the length of the same dynamic string multiple times in a function block, cache the length into a variable (e.g., `size_t pathLen = strlen(pathName);`).
+## 2024-05-24 - Compile-time strlen for Literals
+**Learning:** In the ESP32 codebase, many HTTP and FTP handlers use `strlen()` on hardcoded macros (like `END_BOUNDARY` or `WEBDAV`) and string literals inside loops or hot paths. This causes unnecessary O(N) runtime overhead.
+**Action:** Replace `strlen(MACRO)` with `(sizeof(MACRO) - 1)` to enforce compile-time length calculation, saving CPU cycles during network operations.

--- a/ftp.cpp
+++ b/ftp.cpp
@@ -1,5 +1,5 @@
 // Upload SD card or SPIFFS content to a remote server using FTP or HTTPS
-// 
+//
 // s60sc 2022, 2023
 
 #include "appGlobals.h"
@@ -14,7 +14,7 @@ const char* ftps_rootCACertificate = "";
 char fsServer[MAX_HOST_LEN];
 uint16_t fsPort = 21;
 char FS_Pass[MAX_PWD_LEN]; // FTP password or HTTPS passcode
-char fsWd[FILE_NAME_LEN]; 
+char fsWd[FILE_NAME_LEN];
 
 static bool uploadInProgress = false;
 uint8_t percentLoaded = 0;
@@ -31,7 +31,7 @@ bool fsUse = false; // FTP if false, HTTPS if true
 
 // Upload file of folder of files from local storage to remote HTTPS file server
 // Requires significant heap space due to TLS.
-// Each file POST has following format, where the following values are derived 
+// Each file POST has following format, where the following values are derived
 // from the web page:
 //   Host: FS Server
 //   port: FS port
@@ -61,7 +61,7 @@ Content-Type: "application/octet-stream"
 #define MULTI_TYPE "multipart/form-data; boundary=" BOUNDARY_VAL
 #define JSON_TYPE "application/json"
 #define BIN_TYPE "application/octet-stream"
-#define FORM_DATA "--" BOUNDARY_VAL "\r\nContent-disposition: form-data; name=\"%s%s\"\r\n" CONTENT_TYPE 
+#define FORM_DATA "--" BOUNDARY_VAL "\r\nContent-disposition: form-data; name=\"%s%s\"\r\n" CONTENT_TYPE
 #define END_BOUNDARY "\r\n--" BOUNDARY_VAL "--\r\n"
 #define FILE_NAME "file\"; filename=\""
 #define JSON_DATA "{\"pathname\":\"%s%s/%s\",\"passcode\":\"%s\"}"
@@ -70,7 +70,7 @@ Content-Type: "application/octet-stream"
 NetworkClientSecure hclient;
 char* fsBuff;
 
-static void postHeader(const char* tmethod, const char* contentType, bool isFile, 
+static void postHeader(const char* tmethod, const char* contentType, bool isFile,
   size_t fileSize, const char* fileName) {
   // create http post header
   char* p = fsBuff + FORM_OFFSET; // leave space for http request data
@@ -78,12 +78,12 @@ static void postHeader(const char* tmethod, const char* contentType, bool isFile
     p += sprintf(p, FORM_DATA, "json", "", JSON_TYPE);
     // fsBuff initially contains folder name
     p += sprintf(p, JSON_DATA, fsWd, folderPath, fileName, FS_Pass);
-    p += sprintf(p, "\r\n" FORM_DATA, FILE_NAME, fileName, BIN_TYPE); 
+    p += sprintf(p, "\r\n" FORM_DATA, FILE_NAME, fileName, BIN_TYPE);
   } // else JSON data already loaded by hfsCreateFolder()
   size_t formLen = strlen(fsBuff + FORM_OFFSET);
   // create http request header
   p = fsBuff;
-  if (isFile) fileSize += formLen + strlen(END_BOUNDARY);
+  if (isFile) fileSize += formLen + (sizeof(END_BOUNDARY) - 1);
   p += sprintf(p, POST_HDR, tmethod, fsServer, fileSize, isFile ? MULTI_TYPE : JSON_TYPE);
   size_t reqLen = strlen(fsBuff);
   // concatenate request and form data
@@ -98,11 +98,11 @@ static bool hfsStoreFile(File &fh) {
   // Upload individual file to HTTPS server
   // reject if folder or not valid file type
 #ifdef ISCAM
-  if (!strstr(fh.name(), AVI_EXT) && !strstr(fh.name(), CSV_EXT) && !strstr(fh.name(), SRT_EXT)) return false; 
+  if (!strstr(fh.name(), AVI_EXT) && !strstr(fh.name(), CSV_EXT) && !strstr(fh.name(), SRT_EXT)) return false;
 #else
-  if (!strstr(fh.name(), FILE_EXT)) return false; 
+  if (!strstr(fh.name(), FILE_EXT)) return false;
 #endif
-  LOG_INF("Upload file: %s, size: %s", fh.name(), fmtSize(fh.size()));    
+  LOG_INF("Upload file: %s, size: %s", fh.name(), fmtSize(fh.size()));
 
   // prep POST header and send file to HTTPS server
   postHeader("upload", BIN_TYPE, true, fh.size(), fh.name());
@@ -112,7 +112,7 @@ static bool hfsStoreFile(File &fh) {
   while ((chunksize = fh.read((uint8_t*)fsChunk, CHUNKSIZE))) {
     hclient.write((uint8_t*)fsChunk, chunksize);
     totalSent += chunksize;
-    if (calcProgress(totalSent, fh.size(), 5, percentLoaded)) LOG_INF("Uploaded %u%%", percentLoaded); 
+    if (calcProgress(totalSent, fh.size(), 5, percentLoaded)) LOG_INF("Uploaded %u%%", percentLoaded);
   }
   percentLoaded = 100;
   hclient.println(END_BOUNDARY);
@@ -139,7 +139,7 @@ static bool sendFtpCommand(const char* cmd, const char* param, const char* respC
     rclient.println(param);
   }
   LOG_VRB("Sent cmd: %s%s", cmd, param);
-  
+
   // wait for ftp server response
   uint32_t start = millis();
   while (!rclient.available() && millis() < start + (responseTimeoutSecs * 1000)) delay(1);
@@ -148,7 +148,7 @@ static bool sendFtpCommand(const char* cmd, const char* param, const char* respC
     return false;
   }
   // read in response code and message
-  rclient.read((uint8_t*)respCodeRx, 3); 
+  rclient.read((uint8_t*)respCodeRx, 3);
   respCodeRx[3] = 0; // terminator
   int readLen = rclient.read((uint8_t*)rspBuf, 255);
   if (readLen >= 0) rspBuf[readLen] = 0;
@@ -198,12 +198,12 @@ static void ftpDisconnect() {
 static bool ftpCreateFolder(const char* folderName) {
   // create folder if non existent then change to it
   LOG_VRB("Check for folder %s", folderName);
-  sendFtpCommand("CWD ", folderName, NO_CHECK); 
+  sendFtpCommand("CWD ", folderName, NO_CHECK);
   if (strcmp(respCodeRx, "550") == 0) {
     // non existent folder, create it
     if (!sendFtpCommand("MKD ", folderName, "257")) return false;
     //sendFtpCommand("SITE CHMOD 755 ", folderName, "200", "550"); // unix only
-    if (!sendFtpCommand("CWD ", folderName, "250")) return false;         
+    if (!sendFtpCommand("CWD ", folderName, "250")) return false;
   }
   return true;
 }
@@ -213,45 +213,45 @@ static bool openDataPort() {
   if (!sendFtpCommand("PASV", "", "227")) return false;
   // derive data port number
   char* p = strchr(rspBuf, '('); // skip over initial text
-  int p1, p2;   
+  int p1, p2;
   int items = sscanf(p, "(%*d,%*d,%*d,%*d,%d,%d)", &p1, &p2);
   if (items != 2) {
     LOG_ERR("Failed to parse data port");
     return false;
   }
   int dataPort = (p1 << 8) + p2;
-  
+
   // Connect to data port
   LOG_VRB("Data port: %i", dataPort);
   if (!dclient.connect(fsServer, dataPort)) {
-    LOG_WRN("Data connection failed");   
+    LOG_WRN("Data connection failed");
     return false;
   }
   return true;
 }
 
 static bool ftpStoreFile(File &fh) {
-  // Upload individual file to current folder, overwrite any existing file 
+  // Upload individual file to current folder, overwrite any existing file
   // reject if folder, or not valid file type
 #ifdef ISCAM
-  if (!strstr(fh.name(), AVI_EXT) && !strstr(fh.name(), CSV_EXT) && !strstr(fh.name(), SRT_EXT)) return false; 
+  if (!strstr(fh.name(), AVI_EXT) && !strstr(fh.name(), CSV_EXT) && !strstr(fh.name(), SRT_EXT)) return false;
 #else
-  if (!strstr(fh.name(), FILE_EXT)) return false; 
+  if (!strstr(fh.name(), FILE_EXT)) return false;
 #endif
   char ftpSaveName[FILE_NAME_LEN];
   snprintf(ftpSaveName, sizeof(ftpSaveName), "%s", fh.name());
   size_t fileSize = fh.size();
-  LOG_INF("Upload file: %s, size: %s", ftpSaveName, fmtSize(fileSize));    
+  LOG_INF("Upload file: %s, size: %s", ftpSaveName, fmtSize(fileSize));
 
   // open data connection
   openDataPort();
-  uint32_t writeBytes = 0; 
+  uint32_t writeBytes = 0;
   uint32_t uploadStart = millis();
   size_t readLen, writeLen;
   if (!sendFtpCommand("STOR ", ftpSaveName, "150", "125")) return false;
   do {
     // upload file in chunks
-    readLen = fh.read(fsChunk, CHUNKSIZE);  
+    readLen = fh.read(fsChunk, CHUNKSIZE);
     if (readLen) {
       writeLen = dclient.write((const uint8_t*)fsChunk, readLen);
       writeBytes += writeLen;
@@ -259,7 +259,7 @@ static bool ftpStoreFile(File &fh) {
         LOG_WRN("Upload file to ftp failed");
         return false;
       }
-      if (calcProgress(writeBytes, fileSize, 5, percentLoaded)) LOG_INF("Uploaded %u%%", percentLoaded); 
+      if (calcProgress(writeBytes, fileSize, 5, percentLoaded)) LOG_INF("Uploaded %u%%", percentLoaded);
     }
   } while (readLen > 0);
   dclient.stop();
@@ -277,7 +277,7 @@ static bool ftpStoreFile(File &fh) {
 
 static bool getFolderName(const char* folderName) {
   // extract folder names from path name
-  strcpy(folderPath, folderName); 
+  strcpy(folderPath, folderName);
   int pos = 1; // skip 1st '/'
   // get each folder name in sequence
   bool res = true;
@@ -303,10 +303,10 @@ static bool uploadFolderOrFileFs(const char* fileOrFolder) {
   refreshVal = 1;
   File root = STORAGE.open(fileOrFolder);
   if (!root.isDirectory()) {
-    // Upload a single file 
+    // Upload a single file
     char fsSaveName[FILE_NAME_LEN];
     snprintf(fsSaveName, sizeof(fsSaveName), "%s", root.path());
-    if (getFolderName(root.path())) res = fsUse ? hfsStoreFile(root) : ftpStoreFile(root); 
+    if (getFolderName(root.path())) res = fsUse ? hfsStoreFile(root) : ftpStoreFile(root);
 #ifdef ISCAM
     // upload corresponding csv and srt files if exist
     if (res) {
@@ -325,9 +325,9 @@ static bool uploadFolderOrFileFs(const char* fileOrFolder) {
     }
     if (!res) LOG_WRN("Failed to upload: %s", fsSaveName);
 #endif
-  } else {  
+  } else {
     // Upload a whole folder, file by file
-    LOG_INF("Uploading folder: %s", root.name()); 
+    LOG_INF("Uploading folder: %s", root.name());
     strncpy(folderPath, root.name(), FILE_NAME_LEN - 1);
     res = fsUse ? true : ftpCreateFolder(root.name());
     if (res) {
@@ -343,7 +343,7 @@ static bool uploadFolderOrFileFs(const char* fileOrFolder) {
   }
   refreshVal = saveRefreshVal;
   root.close();
-  fsUse ? remoteServerClose(hclient) : ftpDisconnect(); 
+  fsUse ? remoteServerClose(hclient) : ftpDisconnect();
   return res;
 }
 
@@ -352,15 +352,15 @@ static void fileServerTask(void* parameter) {
 #ifdef ISCAM
   doPlayback = false; // close any current playback
 #endif
-  fsChunk = psramFound() ? (byte*)ps_malloc(CHUNKSIZE) : (byte*)malloc(CHUNKSIZE); 
+  fsChunk = psramFound() ? (byte*)ps_malloc(CHUNKSIZE) : (byte*)malloc(CHUNKSIZE);
   if (strlen(storedPathName) >= 2) {
     File root = STORAGE.open(storedPathName);
     if (!root) LOG_WRN("Failed to open: %s", storedPathName);
-    else { 
+    else {
       bool res = uploadFolderOrFileFs(storedPathName);
       if (res && deleteAfter) deleteFolderOrFile(storedPathName);
     }
-  } else LOG_VRB("Root or null is not allowed %s", storedPathName);  
+  } else LOG_VRB("Root or null is not allowed %s", storedPathName);
   uploadInProgress = false;
   free(fsChunk);
   fsHandle = NULL;
@@ -372,7 +372,7 @@ bool fsStartTransfer(const char* fileFolder) {
   setFolderName(fileFolder, storedPathName);
   if (!uploadInProgress) {
     uploadInProgress = true;
-    if (fsHandle == NULL) xTaskCreateWithCaps(&fileServerTask, "fileServerTask", FS_STACK_SIZE, NULL, FTP_PRI, &fsHandle, STACK_MEM);    
+    if (fsHandle == NULL) xTaskCreateWithCaps(&fileServerTask, "fileServerTask", FS_STACK_SIZE, NULL, FTP_PRI, &fsHandle, STACK_MEM);
     debugMemory("fsStartTransfer");
     return true;
   } else LOG_WRN("Unable to transfer %s as another transfer in progress", storedPathName);

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -8,7 +8,7 @@
 // Using ideas from:
 // - https://github.com/jameszah/ESP32-CAM-Video-Telegram
 // - https://github.com/cotestatnt/AsyncTelegram2
-// 
+//
 //
 // s60sc 2023
 
@@ -16,7 +16,7 @@
 
 #if INCLUDE_TGRAM
 #define TELEGRAM_HOST "api.telegram.org"
-#define LONG_POLL 60 // how long in secs to keep connection open without reply                            
+#define LONG_POLL 60 // how long in secs to keep connection open without reply
 #define MAX_HTTP_MSG 2048 // max size of buffer for HTTP request or response body
 #define FORM_OFFSET 256 // offset in tgramBuff to prepare form data
 #define MAX_TGRAM_SIZE (50 * ONEMEG) // max size for Telegram file upload
@@ -69,7 +69,7 @@ static bool searchJsonResponse(const char* keyName) {
   }
   int valSize = endItem - startItem;
   if (valSize > sizeof(keyValue) - 1) {
-    LOG_WRN("Telegram JSON value too long %d", valSize); 
+    LOG_WRN("Telegram JSON value too long %d", valSize);
     valSize = sizeof(keyValue) - 1;
   }
   strncpy(keyValue, startItem, valSize);
@@ -85,13 +85,13 @@ size_t getResponseHeader(NetworkClientSecure& sclient, const char* host, int wai
   int httpCode = 0;
   uint32_t startTime = millis();
   while (!endOfHeader && millis() - startTime < waitSecs * 1000) {
-    if (sclient.available()) { 
+    if (sclient.available()) {
       String tline = sclient.readStringUntil('\n');
       endOfHeader = tline.length() > 1 ? false : true; // blank line ends header
-      if (!httpCode) sscanf(tline.c_str(), HTTP_CODE, &httpCode);  
+      if (!httpCode) sscanf(tline.c_str(), HTTP_CODE, &httpCode);
       // get contentLength from header
-      if (!contentLen) sscanf(tline.c_str(), "Content-Length: %d\r", &contentLen); 
-    } else delay(100); 
+      if (!contentLen) sscanf(tline.c_str(), "Content-Length: %d\r", &contentLen);
+    } else delay(100);
   }
   if (!endOfHeader) {
     LOG_WRN("Timed out waiting for response from %s", host);
@@ -120,7 +120,7 @@ static bool getTgramResponse() {
     }
     if (contentLen - readLen > 0) LOG_WRN("Timed out waiting for telegram response");
     else {
-      // format tgramBuff for searchJsonResponse() 
+      // format tgramBuff for searchJsonResponse()
       if (readLen != contentLen) LOG_WRN("Telegram data %d not equal to contentLength %d", readLen, contentLen);
       tgramBuff[contentLen] = 0;
       removeChar(tgramBuff, '"');
@@ -135,19 +135,19 @@ static bool getTgramResponse() {
           // have response if result contains data, else just an ack
           if (strcmp(keyValue, "[]")) haveResponse = true;
         }
-      } 
+      }
     }
-    remoteServerClose(tclient); // end of transaction 
+    remoteServerClose(tclient); // end of transaction
   } // else nothing received, so leave connection open
   return haveResponse;
 }
 
-static bool sendTgramHeader(const char* tmethod, const char* contentType, const char* dataType, 
+static bool sendTgramHeader(const char* tmethod, const char* contentType, const char* dataType,
   size_t fileSize, const char* fileName, const char* caption) {
   if (connectTelegram()) {
     // create http post header
     char* p = tgramBuff + FORM_OFFSET; // leave space for http request data
-    bool isFile = dataType != NULL ? true : false; 
+    bool isFile = dataType != NULL ? true : false;
     if (isFile) {
       size_t rem = MAX_HTTP_MSG - FORM_OFFSET;
       int written = snprintf(p, rem, FORM_DATA "chat_id\"\r\n\r\n%s", tgramChatId);
@@ -168,7 +168,7 @@ static bool sendTgramHeader(const char* tmethod, const char* contentType, const 
     // create http request header
     p = tgramBuff;
     size_t rem = FORM_OFFSET;
-    if (isFile) fileSize += formLen + strlen(END_BOUNDARY);
+    if (isFile) fileSize += formLen + (sizeof(END_BOUNDARY) - 1);
     int written = snprintf(p, rem, POST_HDR, tgramToken, tmethod, fileSize);
     if (written > 0 && written < (int)rem) { p += written; rem -= written; }
 
@@ -195,15 +195,15 @@ static bool sendTgramBuff(uint8_t* buffData, size_t buffSize) {
     for (size_t i = 0; i < buffSize; i += CHUNKSIZE) tclient.write(buffData + i, min((int)(buffSize - i), CHUNKSIZE));
     tclient.println(END_BOUNDARY);
     return true;
-  } 
-  return false; 
+  }
+  return false;
 }
-    
+
 bool prepTelegram() {
   // setup and check access to Telegram if required
   if (tgramUse) {
     if (strlen(tgramToken)) {
-      if (tgramBuff == NULL) tgramBuff = psramFound() ? (char*)ps_malloc(MAX_HTTP_MSG) : (char*)malloc(MAX_HTTP_MSG); 
+      if (tgramBuff == NULL) tgramBuff = psramFound() ? (char*)ps_malloc(MAX_HTTP_MSG) : (char*)malloc(MAX_HTTP_MSG);
       // check connection with getme request
       bool res = false;
       sendTgramHeader("getMe", NULL, NULL, 0, NULL, NULL);
@@ -214,9 +214,9 @@ bool prepTelegram() {
       }
       if (res) {
         // response loaded into tgramBuff
-        if (searchJsonResponse("username:")) {      
+        if (searchJsonResponse("username:")) {
           LOG_INF("Connected to Telegram Bot Handle: %s", keyValue);
-          xTaskCreateWithCaps(appSpecificTelegramTask, "telegramTask", TGRAM_STACK_SIZE, NULL, TGRAM_PRI, &telegramHandle, STACK_MEM); 
+          xTaskCreateWithCaps(appSpecificTelegramTask, "telegramTask", TGRAM_STACK_SIZE, NULL, TGRAM_PRI, &telegramHandle, STACK_MEM);
           debugMemory("setupTelegramTask");
           return true;
         } else LOG_WRN("getMe response not parsed %s", tgramBuff);
@@ -224,10 +224,10 @@ bool prepTelegram() {
     } else LOG_WRN("No Telegram Bot token supplied");
   } else LOG_INF("Telegram not being used");
   return false;
-} 
+}
 
 bool getTgramUpdate(char* responseText) {
-  // get and process message from Telegram 
+  // get and process message from Telegram
   if (tclient.connected()) {
     // check for incoming message
     if (getTgramResponse()) {
@@ -247,7 +247,7 @@ bool getTgramUpdate(char* responseText) {
           } else LOG_WRN("No chat id found");
         } else LOG_WRN("Old update_id: %ld", update_id);
       } // no update_id, ignore
-    } 
+    }
   } else {
     // send getUpdates request as not connected
     char* t = tgramBuff + FORM_OFFSET;
@@ -294,11 +294,11 @@ bool sendTgramFile(const char* fileName, const char* contentType, const char* ca
         while ((chunksize = df.read((uint8_t*)tgramBuff, MAX_HTTP_MSG))) {
           tclient.write((uint8_t*)tgramBuff, chunksize);
           totalSent += chunksize;
-          if (calcProgress(totalSent, df.size(), 5, percentLoaded)) LOG_INF("Downloaded %u%%", percentLoaded); 
+          if (calcProgress(totalSent, df.size(), 5, percentLoaded)) LOG_INF("Downloaded %u%%", percentLoaded);
         }
         df.close();
         tclient.println(END_BOUNDARY);
-      } else snprintf(errMsg, sizeof(errMsg) - 1, "File size too large: %s", fmtSize(df.size()));        
+      } else snprintf(errMsg, sizeof(errMsg) - 1, "File size too large: %s", fmtSize(df.size()));
     } else snprintf(errMsg, sizeof(errMsg) - 1, "File does not exist or cannot be opened: %s", fileName);
     if (strlen(errMsg)) {
       LOG_WRN("%s", errMsg);

--- a/webDav.cpp
+++ b/webDav.cpp
@@ -90,7 +90,7 @@ static void sendContentProp(const char* prop, const char* value) {
 static void sendPropResponse(File& file, const char* payload) {
   // send SD properties details to PC
   size_t encodeLen = 3 + strlen(file.path()) * 2;
-  size_t maxLen = strlen(XML2) + encodeLen + strlen(XML3);
+  size_t maxLen = (sizeof(XML2) - 1) + encodeLen + (sizeof(XML3) - 1);
   char resp[maxLen + 1];
   snprintf(resp, maxLen, "%s%s%s", XML2, file.path(), XML3);
   httpd_resp_sendstr_chunk(req, resp);
@@ -214,7 +214,7 @@ static bool handleLock() {
   // provide (dummy) lock while file open
   const char* lockToken = "0123456789012345";
   httpd_resp_set_hdr(req, "Lock-Token", lockToken);
-  char resp[strlen(XML5) + strlen(lockToken) + strlen(XML6) + 1];
+  char resp[(sizeof(XML5) - 1) + strlen(lockToken) + (sizeof(XML6) - 1) + 1];
   snprintf(resp, sizeof(resp), "%s%s%s", XML5, lockToken, XML6);
   httpd_resp_set_type(req, "application/xml;charset=utf-8");
   httpd_resp_sendstr(req, resp);
@@ -278,7 +278,7 @@ static bool checkSamePath(const char *source_path, const char *dest_path) {
   size_t src_len = src_slash - source_path;
   size_t dest_len = dest_slash - dest_path;
   if (src_len != dest_len) return false;
-  
+
   return strncmp(source_path, dest_path, src_len) == 0;
 }
 
@@ -332,7 +332,7 @@ bool handleWebDav(httpd_req_t* rreq) {
   if (req->method == HTTP_OPTIONS) return handleOptions(); // supported options
   if (!checkAuth(req)) return false;
 
-  snprintf(pathName, sizeof(pathName), "%s", req->uri + strlen(WEBDAV)); // strip out "/webdav"
+  snprintf(pathName, sizeof(pathName), "%s", req->uri + (sizeof(WEBDAV) - 1)); // strip out "/webdav"
   if (strlen(pathName) > 0 && pathName[strlen(pathName) - 1] == '/') pathName[strlen(pathName) - 1] = 0; // remove final / if present
   if (!strlen(pathName)) strcpy(pathName, "/"); // if pathname empty, use single /
   urlDecode(pathName);

--- a/webServer.cpp
+++ b/webServer.cpp
@@ -100,7 +100,7 @@ bool checkAuth(httpd_req_t* req) {
     char credentials[credLen];
     snprintf(credentials, credLen, "%s:%s", Auth_Name, Auth_Pass);
     const char* encodedCreds = encode64(credentials);
-    size_t expectedLen = strlen("Basic ") + strlen(encodedCreds) + 1;
+    size_t expectedLen = (sizeof("Basic ") - 1) + strlen(encodedCreds) + 1;
     char expectedAuth[expectedLen];
     snprintf(expectedAuth, expectedLen, "Basic %s", encodedCreds);
 
@@ -347,7 +347,7 @@ void sendSSE(const char* eventType, const char* eventData) {
     snprintf(eventMsg, 30 - 1, "event: %s\ndata: ", eventType);
     int res = httpd_socket_send(sseSocketHD, sseSocketFD, eventMsg, strlen(eventMsg), 0);
     res = httpd_socket_send(sseSocketHD, sseSocketFD, eventData, strlen(eventData), 0);
-    res = httpd_socket_send(sseSocketHD, sseSocketFD, SSESEP, strlen(SSESEP), 0);
+    res = httpd_socket_send(sseSocketHD, sseSocketFD, SSESEP, (sizeof(SSESEP) - 1), 0);
     if (res == HTTPD_SOCK_ERR_TIMEOUT) LOG_WRN("Timeout/interrupted while using socket");
     if (res == HTTPD_SOCK_ERR_FAIL) LOG_WRN("Unrecoverable error while using socket");
     if (res == HTTPD_SOCK_ERR_INVALID) LOG_WRN("Invalid arguments %s, %s", eventType, eventData);


### PR DESCRIPTION
💡 What
Replaced multiple `strlen(MACRO)` and `strlen("literal")` calls with `(sizeof(MACRO) - 1)` across `webServer.cpp`, `webDav.cpp`, `ftp.cpp`, and `telegram.cpp`.

🎯 Why
Using `strlen()` on hardcoded macros (like `END_BOUNDARY` or `WEBDAV`) causes unnecessary O(N) runtime overhead during HTTP/network operations. Using `sizeof(...) - 1` ensures the length is calculated once at compile time.

📊 Impact
Saves CPU cycles during string processing and network payload construction, contributing to a lighter, faster application profile on the ESP32.

🔬 Measurement
Review the diff to confirm all replacements target string literals/macros and correctly adjust for the null terminator. The mock C++ and Python testing suites have passed successfully.

---
*PR created automatically by Jules for task [9586712741430776817](https://jules.google.com/task/9586712741430776817) started by @ManupaKDU*