### PR TITLE
⚡ Bolt: Use compile-time length calculation for literal strings

### DIFF
--- a/ftp.cpp
+++ b/ftp.cpp
@@ -83,7 +83,7 @@ static void postHeader(const char* tmethod, const char* contentType, bool isFile
   size_t formLen = strlen(fsBuff + FORM_OFFSET);
   // create http request header
   p = fsBuff;
-  if (isFile) fileSize += formLen + strlen(END_BOUNDARY);
+  if (isFile) fileSize += formLen + (sizeof(END_BOUNDARY) - 1);
   p += sprintf(p, POST_HDR, tmethod, fsServer, fileSize, isFile ? MULTI_TYPE : JSON_TYPE);
   size_t reqLen = strlen(fsBuff);
   // concatenate request and form data

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -168,7 +168,7 @@ static bool sendTgramHeader(const char* tmethod, const char* contentType, const 
     // create http request header
     p = tgramBuff;
     size_t rem = FORM_OFFSET;
-    if (isFile) fileSize += formLen + strlen(END_BOUNDARY);
+    if (isFile) fileSize += formLen + (sizeof(END_BOUNDARY) - 1);
     int written = snprintf(p, rem, POST_HDR, tgramToken, tmethod, fileSize);
     if (written > 0 && written < (int)rem) { p += written; rem -= written; }
 

--- a/webDav.cpp
+++ b/webDav.cpp
@@ -214,7 +214,7 @@ static bool handleLock() {
   // provide (dummy) lock while file open
   const char* lockToken = "0123456789012345";
   httpd_resp_set_hdr(req, "Lock-Token", lockToken);
-  char resp[strlen(XML5) + strlen(lockToken) + strlen(XML6) + 1];
+  char resp[(sizeof(XML5) - 1) + strlen(lockToken) + (sizeof(XML6) - 1) + 1];
   snprintf(resp, sizeof(resp), "%s%s%s", XML5, lockToken, XML6);
   httpd_resp_set_type(req, "application/xml;charset=utf-8");
   httpd_resp_sendstr(req, resp);


### PR DESCRIPTION
### 💡 What
Replaced runtime `strlen` calculations on literal string macros (`END_BOUNDARY`, `XML5`, `XML6`) with compile-time `(sizeof(MACRO) - 1)` in `ftp.cpp`, `telegram.cpp`, and `webDav.cpp`.

### 🎯 Why
`strlen` causes an O(N) evaluation at runtime, where the CPU has to iterate character by character to find the null terminator. Using `sizeof` on string literals allows the compiler to evaluate the length statically at compile-time, which is a common and efficient C/C++ performance optimization pattern (especially for embedded devices like the ESP32 where cycles count).

### 📊 Impact
Provides a small micro-optimization performance improvement by saving CPU cycles previously wasted traversing these literal string variables multiple times (particularly during HTTP and FTP upload/header creation).

### 🔬 Measurement
The modified codebase compiles cleanly, and local test suites pass without regression. The logic accurately and statically evaluates the same correct string length dynamically.

---
*PR created automatically by Jules for task [1984527670036224081](https://jules.google.com/task/1984527670036224081) started by @ManupaKDU*