### PR TITLE
🎨 Palette: Add tooltips to camera setting sliders

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1098,33 +1098,33 @@
                   </div>
                   <div class="input-group" id="aec_value-group">
                     <label for="aec_value"id="aec_value_lab">Manual Exposure</label>
-                    <input type="range" id="aec_value" min="0" max="1200" value="204">
+                    <input title="Manual Exposure" type="range" id="aec_value" min="0" max="1200" value="204">
                   </div>
                   <div class="input-group" id="aec2-group">
                     <label for="aec2" id="aec2_lab">AEC DSP</label>
                     <div class="switch">
                       <input id="aec2" type="checkbox" checked="checked">
-                      <label class="slider" for="aec2"></label>
+                      <label title="AEC DSP" class="slider" for="aec2"></label>
                     </div>
                   </div>
                   <div class="input-group hidden" id="agc_gain-group">
                     <label for="agc_gain" id="agc_gain_lab">Gain</label>
                     <div name="rangeMin">1x</div>
-                    <input type="range" id="agc_gain" min="0" max="30" value="5">
+                    <input title="Gain" type="range" id="agc_gain" min="0" max="30" value="5">
                     <div name="rangeMax">31x</div>
                   </div>
                   <div class="input-group" id="hmirror-group">
                     <label for="hmirror">H-Mirror</label>
                     <div class="switch">
                       <input id="hmirror" type="checkbox" checked="checked">
-                      <label class="slider" for="hmirror"></label>
+                      <label title="Horizontal Mirror" class="slider" for="hmirror"></label>
                     </div>
                   </div>
                   <div class="input-group" id="vflip-group">
                     <label for="vflip">V-Flip</label>
                     <div class="switch">
                       <input id="vflip" type="checkbox" checked="checked">
-                      <label class="slider" for="vflip"></label>
+                      <label title="Vertical Flip" class="slider" for="vflip"></label>
                     </div>
                   </div>
                   <div class="ALLOV hidden">
@@ -1132,80 +1132,80 @@
                         <label for="awb">AWB Enable</label>
                         <div class="switch">
                             <input id="awb" type="checkbox" checked="checked">
-                            <label class="slider" for="awb"></label>
+                            <label title="AWB" class="slider" for="awb"></label>
                         </div>
                     </div>
                     <div class="input-group" id="awb_gain-group">
                       <label for="awb_gain" id="awbg_lab">AWB Gain</label>
                       <div class="switch">
                         <input id="awb_gain" type="checkbox" checked="checked">
-                        <label class="slider" for="awb_gain"></label>
+                        <label title="AWB Gain" class="slider" for="awb_gain"></label>
                       </div>
                     </div>
                     <div class="input-group" id="aec-group">
                       <label for="aec">AEC Enable</label>
                       <div class="switch">
                         <input id="aec" type="checkbox" checked="checked">
-                        <label class="slider" for="aec"></label>
+                        <label title="AEC Sensor" class="slider" for="aec"></label>
                       </div>
                     </div>
                     <div class="input-group" id="ae_level-group">
                       <label for="ae_level">Exposure Level</label>
-                      <input type="range" id="ae_level" min="-2" max="2" value="0">
+                      <input title="AE Level" type="range" id="ae_level" min="-2" max="2" value="0">
                     </div>
                     <div class="input-group" id="dcw-group">
                       <label for="dcw" id="dcw_lab">DCW (Downsize)</label>
                       <div class="switch">
                         <input id="dcw" type="checkbox" checked="checked">
-                        <label class="slider" for="dcw"></label>
+                        <label title="DCW (Downsize EN)" class="slider" for="dcw"></label>
                       </div>
                     </div>
                     <div class="input-group" id="agc-group">
                       <label for="agc">AGC Enable</label>
                       <div class="switch">
                         <input id="agc" type="checkbox" checked="checked">
-                        <label class="slider" for="agc"></label>
+                        <label title="AGC" class="slider" for="agc"></label>
                       </div>
                     </div>
                     <div class="input-group" id="gainceiling-group">
                       <label for="gainceiling">Gain Ceiling</label>
                       <div name="rangeMin">2x</div>
-                      <input type="range" id="gainceiling" min="0" max="6" value="0">
+                      <input title="Gain Ceiling" type="range" id="gainceiling" min="0" max="6" value="0">
                       <div name="rangeMax">128x</div>
                     </div>
                     <div class="input-group" id="lenc-group">
                       <label for="lenc">Lens Correction</label>
                       <div class="switch">
                         <input id="lenc" type="checkbox" checked="checked">
-                        <label class="slider" for="lenc"></label>
+                        <label title="Lens Correction" class="slider" for="lenc"></label>
                       </div>
                     </div>
                     <div class="input-group" id="colorbar-group">
                       <label for="colorbar">Color Bar</label>
                       <div class="switch">
                         <input id="colorbar" type="checkbox">
-                        <label class="slider" for="colorbar"></label>
+                        <label title="Color Bar" class="slider" for="colorbar"></label>
                       </div>
                     </div>
                     <div class="input-group" id="bpc-group">
                       <label for="bpc">BPC</label>
                       <div class="switch">
                         <input id="bpc" type="checkbox" checked="checked">
-                        <label class="slider" for="bpc"></label>
+                        <label title="BPC" class="slider" for="bpc"></label>
                       </div>
                     </div>
                     <div class="input-group" id="wpc-group">
                       <label for="wpc">WPC</label>
                       <div class="switch">
                         <input id="wpc" type="checkbox" checked="checked">
-                        <label class="slider" for="wpc"></label>
+                        <label title="WPC" class="slider" for="wpc"></label>
                       </div>
                     </div>
                     <div class="input-group" id="raw_gma-group">
                       <label for="raw_gma">GMA Enable</label>
                       <div class="switch">
                         <input id="raw_gma" type="checkbox" checked="checked">
-                        <label class="slider" for="raw_gma"></label>
+                        <label title="Raw GMA" class="slider" for="raw_gma"></label>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
💡 What
Added `title` attributes to various range inputs and custom toggle sliders (styled `<label>` elements acting as switch tracks) in `data/MJPEG2SD.htm`.

🎯 Why
This micro-UX improvement provides native browser tooltips when a user hovers over the controls themselves, making the interface more intuitive and accessible, particularly for toggle sliders where the visual control is separate from the text label.

📸 Before/After
Tooltips are now displayed on hover for range inputs and slider toggles.

♿ Accessibility
Improves accessibility by ensuring that interactive controls have descriptive tooltips via native `title` attributes, aiding users relying on screen readers or those who need additional context when hovering.

---
*PR created automatically by Jules for task [6139422751285669808](https://jules.google.com/task/6139422751285669808) started by @ManupaKDU*