### PR TITLE
⚡ Bolt: Optimize pathName string length calculations in WebDAV handler

### DIFF
--- a/webDav.cpp
+++ b/webDav.cpp
@@ -332,9 +332,13 @@ bool handleWebDav(httpd_req_t* rreq) {
   if (req->method == HTTP_OPTIONS) return handleOptions(); // supported options
   if (!checkAuth(req)) return false;
 
-  snprintf(pathName, sizeof(pathName), "%s", req->uri + strlen(WEBDAV)); // strip out "/webdav"
-  if (strlen(pathName) > 0 && pathName[strlen(pathName) - 1] == '/') pathName[strlen(pathName) - 1] = 0; // remove final / if present
-  if (!strlen(pathName)) strcpy(pathName, "/"); // if pathname empty, use single /
+  snprintf(pathName, sizeof(pathName), "%s", req->uri + (sizeof(WEBDAV) - 1)); // strip out "/webdav"
+  size_t pathLen = strlen(pathName); // Bolt: Cache length to avoid redundant O(N) evaluation
+  if (pathLen > 0 && pathName[pathLen - 1] == '/') {
+    pathName[pathLen - 1] = 0; // remove final / if present
+    pathLen--;
+  }
+  if (!pathLen) strcpy(pathName, "/"); // if pathname empty, use single /
   urlDecode(pathName);
   if (isPathTraversal(pathName)) {
     httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Path traversal not allowed");


### PR DESCRIPTION
💡 **What**: Optimized string parsing in `webDav.cpp:handleWebDav` by replacing redundant `strlen(pathName)` evaluations with a single cached `pathLen` variable, and replacing `strlen(WEBDAV)` with a compile-time `sizeof(WEBDAV) - 1`.
🎯 **Why**: Previously, when processing WebDAV HTTP requests, the string `pathName` was traversed with `strlen()` up to three times consecutively to calculate bounds for stripping trailing slashes and checking emptiness. By caching the length, we reduce string processing overhead from multiple O(N) evaluations to a single O(N) pass. Additionally, evaluating the `WEBDAV` macro length at compile time skips a runtime string iteration.
📊 **Impact**: Eliminates redundant string length iterations on every WebDAV request, marginally reducing CPU cycle time for string parsing operations and providing a micro-optimization for high-frequency string handlers.
🔬 **Measurement**: Verified the functional correctness of the WebDAV path manipulation using the repository's C++ unit test suite (`test_mock.cpp`) which confirmed that paths (both empty and trailing slashes) are properly evaluated. Python UI test suites run to ensure no regressions.

---
*PR created automatically by Jules for task [13169984651912869013](https://jules.google.com/task/13169984651912869013) started by @ManupaKDU*