### PR TITLE
⚡ Bolt: Optimize redundant strlen traversal overheads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -97,3 +97,6 @@
 ## 2024-05-24 - Compile-time strlen for Literals
 **Learning:** In the ESP32 codebase, many HTTP and FTP handlers use `strlen()` on hardcoded macros (like `END_BOUNDARY` or `WEBDAV`) and string literals inside loops or hot paths. This causes unnecessary O(N) runtime overhead.
 **Action:** Replace `strlen(MACRO)` with `(sizeof(MACRO) - 1)` to enforce compile-time length calculation, saving CPU cycles during network operations.
+## 2024-05-25 - Avoid O(N) strlen overhead after snprintf
+**Learning:** Determining the length of a string immediately after formatting it with `snprintf` by calling `strlen()` causes an unnecessary O(N) traversal of the string that was just constructed.
+**Action:** Use the return value of `snprintf` (clamped to the buffer size if it exceeds the bounds, e.g., `if (len >= size) len = size - 1;`) to determine the length of the formatted string in O(1) time.

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -46,8 +46,9 @@ static char mqttPublishTopic[FILE_NAME_LEN] = "";
 
 void mqtt_client_publish(const char* topic, const char* payload){
   if (!mqtt_client || !mqttConnected) return;
-  int id = esp_mqtt_client_publish(mqtt_client, topic, payload, strlen(payload), MQTT_QOS, MQTT_RETAIN);
-  LOG_VRB("Mqtt pub, topic:%s, ID:%d, length:%i", topic, id, strlen(payload));
+  size_t payloadLen = strlen(payload);
+  int id = esp_mqtt_client_publish(mqtt_client, topic, payload, payloadLen, MQTT_QOS, MQTT_RETAIN);
+  LOG_VRB("Mqtt pub, topic:%s, ID:%d, length:%zu", topic, id, payloadLen);
   LOG_VRB("Mqtt pub, payload:%s", payload);
 }
 

--- a/webServer.cpp
+++ b/webServer.cpp
@@ -328,13 +328,13 @@ bool parseJson(int rxSize) {
 static esp_err_t sseHandler(httpd_req_t *req) {
   if (!checkAuth(req)) return ESP_OK;
   // enable Server Sent Events
-  const char* sseHeader = "HTTP/1.1 200 OK\r\n"
-                          "Cache-Control: no-store\r\n"
-                          "Connection: keep-alive\r\n"
-                          "Content-Type: text/event-stream\r\n\r\n";
+  const char sseHeader[] = "HTTP/1.1 200 OK\r\n"
+                           "Cache-Control: no-store\r\n"
+                           "Connection: keep-alive\r\n"
+                           "Content-Type: text/event-stream\r\n\r\n";
   sseSocketHD = req->handle;
   sseSocketFD = httpd_req_to_sockfd(req);
-  httpd_socket_send(sseSocketHD, sseSocketFD, sseHeader, strlen(sseHeader), 0);
+  httpd_socket_send(sseSocketHD, sseSocketFD, sseHeader, sizeof(sseHeader) - 1, 0);
   sendSSE("open", "opened");
   return ESP_OK;
 }
@@ -344,8 +344,9 @@ void sendSSE(const char* eventType, const char* eventData) {
   // send event data to browser
   if (sseSocketFD > 0) {
     char eventMsg[30];
-    snprintf(eventMsg, 30 - 1, "event: %s\ndata: ", eventType);
-    int res = httpd_socket_send(sseSocketHD, sseSocketFD, eventMsg, strlen(eventMsg), 0);
+    int msgLen = snprintf(eventMsg, sizeof(eventMsg), "event: %s\ndata: ", eventType);
+    if (msgLen >= sizeof(eventMsg)) msgLen = sizeof(eventMsg) - 1;
+    int res = httpd_socket_send(sseSocketHD, sseSocketFD, eventMsg, msgLen, 0);
     res = httpd_socket_send(sseSocketHD, sseSocketFD, eventData, strlen(eventData), 0);
     res = httpd_socket_send(sseSocketHD, sseSocketFD, SSESEP, (sizeof(SSESEP) - 1), 0);
     if (res == HTTPD_SOCK_ERR_TIMEOUT) LOG_WRN("Timeout/interrupted while using socket");


### PR DESCRIPTION
💡 **What**
1. Replaced `strlen(eventMsg)` with the cached return value of `snprintf` in `sendSSE` (`webServer.cpp`).
2. Replaced `strlen(sseHeader)` with a compile-time `sizeof(sseHeader) - 1` by defining the literal as a `const char[]` instead of `const char*` (`webServer.cpp`).
3. Cached `strlen(payload)` into a `payloadLen` variable in `mqtt_client_publish` to prevent redundant calculations (`mqtt.cpp`).

🎯 **Why**
`strlen` operates in O(N) time. By replacing it with cached values or compile-time calculations in heavily used functions like Server-Sent Events (SSE) and MQTT publishers, we eliminate redundant string traversals. This reduces CPU cycles and branch prediction overhead on the ESP32.

📊 **Impact**
- O(N) -> O(1) length calculation for SSE framing and headers, minimizing overhead during high-frequency HTTP streaming.
- Halves the number of `strlen` operations per MQTT publish.

🔬 **Measurement**
- Ensure the project continues to compile via `g++ -o test_mock_bin test_mock.cpp && ./test_mock_bin`.
- Ensure frontend SSE connectivity logic remains functionally identical via `python test_playwright.py`.

---
*PR created automatically by Jules for task [9291637153852077139](https://jules.google.com/task/9291637153852077139) started by @ManupaKDU*