### PR TITLE
🎨 Palette: Improve password toggle accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-06-26 - Native Tooltips for Range Inputs
 **Learning:** Native `title` tooltips on `<input type="range">` elements (like Brightness, Contrast, Saturation) provide an immediate, accessible way to explain the purpose of icon-heavy or context-dependent sliders without requiring additional screen space or custom JS tooltip components.
 **Action:** When adding missing tooltips to a cluster of related inputs, use Python byte-string replacement for multi-line HTML files to avoid newline issues and accurately target specific ID attributes, ensuring all inputs in a logical grouping receive consistent labeling.
+## 2024-05-24 - Improve password visibility toggle accessibility
+**Learning:** Adding semantic keyboard accessibility (`onkeydown` to support Enter/Space) and stateful title tooltips to icon-only buttons drastically improves screen reader context and keyboard navigation in custom config forms.
+**Action:** When adding or fixing custom icon-only toggle buttons in the HTML, always ensure they are fully operable via keyboard (`onkeydown` handling `Enter` and `Space`) and provide dynamic `title` or `aria-label` attributes reflecting their current toggle state.

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -854,7 +854,7 @@
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
                       <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group">
@@ -897,7 +897,7 @@
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
                       <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -929,7 +929,7 @@
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
                       <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -946,7 +946,7 @@
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
                       <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="auth-group">

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1343,7 +1343,7 @@
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
                       <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group">
@@ -1386,7 +1386,7 @@
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
                       <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -1418,7 +1418,7 @@
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
                       <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -1435,7 +1435,7 @@
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
                       <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="auth-group">


### PR DESCRIPTION
💡 What
Added keyboard navigation support (Enter/Space to toggle) and dynamic tooltip titles (Show/Hide password) to the password visibility toggles (`👁️`/`🙈`) across all configuration forms in `MJPEG2SD.htm` and `Auxil.htm`.

🎯 Why
Previously, these icon-only toggles were styled as buttons (`role="button"`, `tabindex="0"`) but were unreachable via keyboard interaction since they only listened for `onclick`. Furthermore, their static `title="Show password"` remained inaccurate when the password was actually revealed, causing confusion for screen reader users and tooltips.

📸 Before/After
(Visual representation - the underlying code handles dynamic titles)
- **Before:** Keyboard interaction was ignored; title always "Show password".
- **After:** Pressing Enter or Space triggers the toggle; title correctly updates to "Hide password" when the password is shown.

♿ Accessibility
- Adds `onkeydown` event listener to capture Enter (`'Enter'`) and Space (`' '`) keystrokes to trigger the toggle action, enabling full keyboard navigation.
- Dynamically updates the native `title` attribute to reflect the current state (Hide vs. Show), significantly improving context for screen readers and providing accurate hover tooltips.

---
*PR created automatically by Jules for task [1534887823964249861](https://jules.google.com/task/1534887823964249861) started by @ManupaKDU*