### PR TITLE
🎨 Palette: [UX improvement] Add tooltips and ARIA labels to Device Hub buttons

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1726,9 +1726,9 @@
         <!-- Input field for users to enter individual IPs -->
         <label for="ipInput">Enter IP address:&nbsp;</label>
         <input type="text" id="ipInput" class="local" placeholder="e.g. 192.168.1.100">
-        <button id="addIpButton" class="local" onclick="addIP()">Add IP</button>
-        <button id="clearStorageButton" class="local" onclick="clearLocalStorage()">Delete All</button>
-        <button id="refreshAllButton" class="local" onclick="refreshAllContainers(true)">Refresh</button>
+        <button id="addIpButton" class="local" title="Add a new camera to the Hub" aria-label="Add IP address" onclick="addIP()">Add IP</button>
+        <button id="clearStorageButton" class="local" title="Remove all saved cameras" aria-label="Delete all IP addresses" onclick="clearLocalStorage()">Delete All</button>
+        <button id="refreshAllButton" class="local" title="Refresh all camera streams" aria-label="Refresh all cameras" onclick="refreshAllContainers(true)">Refresh</button>
       </div>
       <!-- Container to hold the image elements -->
       <div id="imageContainer"></div>


### PR DESCRIPTION
**💡 What**
Added `title` (tooltip) and `aria-label` attributes to the "Add IP", "Delete All", and "Refresh" buttons within the Camera Hub (`DeviceHub`) panel.

**🎯 Why**
Previously, these buttons had text labels but lacked tooltips and explicit ARIA labels. For users interacting via screen readers, having descriptive `aria-label`s makes the exact purpose of these buttons clearer, particularly because context like "Delete All" might be vague without stating *what* is being deleted. For visual users, tooltips provide an extra touch of clarity.

**📸 Before/After**
*Before:* `<button id="clearStorageButton" class="local" onclick="clearLocalStorage()">Delete All</button>`
*After:* `<button id="clearStorageButton" class="local" title="Remove all saved cameras" aria-label="Delete all IP addresses" onclick="clearLocalStorage()">Delete All</button>`

**♿ Accessibility**
Improves accessibility by ensuring icon/text buttons in form sections provide clear, accessible labels (`aria-label`) and on-hover instructions (`title`).

---
*PR created automatically by Jules for task [1799872367261345811](https://jules.google.com/task/1799872367261345811) started by @ManupaKDU*