### PR TITLE
🎨 Palette: Improve keyboard accessibility for password toggles

### DIFF
--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -854,7 +854,7 @@
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
                       <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group">
@@ -897,7 +897,7 @@
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
                       <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -929,7 +929,7 @@
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
                       <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -946,7 +946,7 @@
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
                       <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="auth-group">

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1343,7 +1343,7 @@
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
                       <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group">
@@ -1386,7 +1386,7 @@
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
                       <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -1418,7 +1418,7 @@
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
                       <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -1435,7 +1435,7 @@
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
                       <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="auth-group">


### PR DESCRIPTION
### 💡 What
Added `onkeydown` event handlers to the password visibility toggle buttons (👁️/🙈) across the UI (in both `MJPEG2SD.htm` and `Auxil.htm`).

### 🎯 Why
The password toggle buttons already had `role="button"` and `tabindex="0"`, making them discoverable and focusable for keyboard users. However, they lacked keyboard event listeners. By adding `onkeydown`, users navigating with a keyboard or screen reader can now correctly trigger the toggle using the `Enter` or `Space` keys, ensuring compliance with expected standard ARIA button behaviors.

### 📸 Before/After
_Visual change is non-existent, but interaction has changed to allow keyboard operation._

### ♿ Accessibility
- Added explicit keyboard support (`Enter` and `Space`) for `span` elements acting as toggle buttons, significantly improving usability for users relying on keyboard navigation or assistive technologies.

---
*PR created automatically by Jules for task [6278633781846658996](https://jules.google.com/task/6278633781846658996) started by @ManupaKDU*