### PR TITLE
🎨 Palette: [UX improvement] Enhance password toggles and stream icons

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -219,9 +219,12 @@
        background: var(--buttonActive);
       }
 
-      button:focus-visible, [role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+      button:focus-visible, [role="button"]:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible, .password-toggle:focus-visible, .iconSize:focus-visible {
         outline: 2px solid var(--buttonActive);
         outline-offset: 2px;
+      }
+      .password-toggle {
+        cursor: pointer;
       }
 
       button:hover {
@@ -1343,7 +1346,7 @@
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
                       <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="togglePassword(this, 'ST_Pass')" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group">
@@ -1386,7 +1389,7 @@
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
                       <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="togglePassword(this, 'FS_Pass')" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -1418,7 +1421,7 @@
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
                       <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="togglePassword(this, 'SMTP_Pass')" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
@@ -1435,7 +1438,7 @@
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
                       <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
-                      <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';}else{p.type='password';this.innerText='👁️';}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
+                      <span class="password-toggle local" onclick="togglePassword(this, 'Auth_Pass')" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="auth-group">
@@ -1512,12 +1515,12 @@
         <figure>
           <div id="stream-container" class="image-container hidden">
             <div class="iconSize" id="closeStream" title="Close screen" role="button" tabindex="0" aria-label="Close screen">×</div>
-            <div class="iconSize" id="rotate" title="Rotate screen" role="button" tabindex="0" aria-label="Rotate screen">@</div>
-            <div class="iconSize" id="actualSize" title="Actual size" role="button" tabindex="0" aria-label="Actual size">-</div>
-            <div class="iconSize" id="maxFit" title="Fit to browser" role="button" tabindex="0" aria-label="Fit to browser">#</div>
-            <div class="iconSize" id="fullAspect" title="Full screen with aspect" role="button" tabindex="0" aria-label="Full screen with aspect">&curren;</div>
-            <div class="iconSize" id="fullSize" title="Full screen" role="button" tabindex="0" aria-label="Full screen">&rect;</div>
-            <div class="iconSize" id="saveImage" title="Download screenshot" role="button" tabindex="0" aria-label="Download screenshot">v</div>
+            <div class="iconSize" id="rotate" title="Rotate screen" role="button" tabindex="0" aria-label="Rotate screen">↻</div>
+            <div class="iconSize" id="actualSize" title="Actual size" role="button" tabindex="0" aria-label="Actual size">1x</div>
+            <div class="iconSize" id="maxFit" title="Fit to browser" role="button" tabindex="0" aria-label="Fit to browser">⤢</div>
+            <div class="iconSize" id="fullAspect" title="Full screen with aspect" role="button" tabindex="0" aria-label="Full screen with aspect">🔳</div>
+            <div class="iconSize" id="fullSize" title="Full screen" role="button" tabindex="0" aria-label="Full screen">⛶</div>
+            <div class="iconSize" id="saveImage" title="Download screenshot" role="button" tabindex="0" aria-label="Download screenshot">⬇</div>
             <div id="RCenable" class="hidden">
               <div class="RCcontrolFmt RCbuttonFmt" title="Switch RC controls on / off" role="button" tabindex="0" aria-label="Switch RC controls on / off">
                 <svg class="svgIcon">
@@ -1740,6 +1743,19 @@
 
     <script>
       'use strict'
+
+      function togglePassword(btn, inputId) {
+        const p = document.getElementById(inputId);
+        if (p.type === 'password') {
+          p.type = 'text';
+          btn.innerText = '🙈';
+          btn.title = 'Hide password';
+        } else {
+          p.type = 'password';
+          btn.innerText = '👁️';
+          btn.title = 'Show password';
+        }
+      }
 
       let refreshInterval = 5000;
       let heartbeatInterval = 5000;

--- a/data/common.js
+++ b/data/common.js
@@ -671,7 +671,7 @@
             // trigger click for elements with role="button" or SVG rects when Enter or Space is pressed
             if (keyPress === 13 || keyPress === 32) {
               const e = event.target;
-              if (e.getAttribute('role') === 'button' || e.nodeName === 'rect') {
+              if (e.getAttribute('role') === 'button' || e.nodeName === 'rect' || e.classList.contains('iconSize')) {
                 event.preventDefault(); // prevent scrolling for Space
                 if (e.nodeName === 'DIV') {
                   const rect = e.querySelector('rect');


### PR DESCRIPTION
### 💡 What
- Replaced repetitive inline JavaScript for the password toggles with a clean reusable function `togglePassword` that dynamically updates both the icon (👁️/🙈) and tooltip ("Show password"/"Hide password").
- Replaced obscure ASCII stream control icons (`@`, `-`, `#`, `&curren;`, `&rect;`, `v`) with standard intuitive Unicode symbols (`↻`, `1x`, `⤢`, `🔳`, `⛶`, `⬇`).
- Added focus outlines and pointer cursors to interactive icons for better keyboard navigation.
- Ensured `.iconSize` stream controls can be triggered by keyboard Space/Enter events.

### 🎯 Why
To make the web UI more intuitive and pleasant to use, while ensuring that all interactive elements are fully accessible to keyboard users by providing clear visual focus indicators. 

### 📸 Before/After
*(Verified locally via Playwright screenshots)*
- **Before:** Password toggles only changed the icon character but kept the tooltip static. Stream icons used confusing characters like `@` for rotate and `#` for fit. Keyboard navigation across stream buttons did not clearly show focus rings.
- **After:** Password toggles dynamically update their state and tooltips. Stream buttons use clear, recognizable Unicode symbols. Tabbing across interactive elements highlights them clearly with standard focus rings.

### ♿ Accessibility
- Added `.password-toggle:focus-visible` and `.iconSize:focus-visible` to CSS to display clear focus rings for keyboard users.
- Ensured `Enter` and `Space` keydown events properly trigger the stream control icons in `data/common.js`.
- Added `cursor: pointer` to the password toggles.

---
*PR created automatically by Jules for task [9111086122687071070](https://jules.google.com/task/9111086122687071070) started by @ManupaKDU*