### PR TITLE
⚡ Bolt: Eliminate redundant strlen traversals

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -97,3 +97,7 @@
 ## 2024-05-24 - Compile-time strlen for Literals
 **Learning:** In the ESP32 codebase, many HTTP and FTP handlers use `strlen()` on hardcoded macros (like `END_BOUNDARY` or `WEBDAV`) and string literals inside loops or hot paths. This causes unnecessary O(N) runtime overhead.
 **Action:** Replace `strlen(MACRO)` with `(sizeof(MACRO) - 1)` to enforce compile-time length calculation, saving CPU cycles during network operations.
+
+## 2024-06-25 - Redundant strlen calls after formatting functions
+**Learning:** Calling `strlen()` on a string buffer immediately after formatting it with `snprintf()` or `sprintf()` introduces an unnecessary O(N) evaluation, as the exact length of the formatted string is already returned by the formatting function.
+**Action:** Always capture and use the integer return value of `snprintf()` or `sprintf()` (clamping it to the buffer size bounds if necessary) instead of subsequently calling `strlen(buffer)`.

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -46,8 +46,9 @@ static char mqttPublishTopic[FILE_NAME_LEN] = "";
 
 void mqtt_client_publish(const char* topic, const char* payload){
   if (!mqtt_client || !mqttConnected) return;
-  int id = esp_mqtt_client_publish(mqtt_client, topic, payload, strlen(payload), MQTT_QOS, MQTT_RETAIN);
-  LOG_VRB("Mqtt pub, topic:%s, ID:%d, length:%i", topic, id, strlen(payload));
+  size_t payloadLen = strlen(payload);
+  int id = esp_mqtt_client_publish(mqtt_client, topic, payload, payloadLen, MQTT_QOS, MQTT_RETAIN);
+  LOG_VRB("Mqtt pub, topic:%s, ID:%d, length:%u", topic, id, (unsigned int)payloadLen);
   LOG_VRB("Mqtt pub, payload:%s", payload);
 }
 

--- a/prefs.cpp
+++ b/prefs.cpp
@@ -132,11 +132,14 @@ static void saveConfigVect() {
     configs.erase(unique(configs.begin(), configs.end()), configs.end()); // remove any dups
     for (const auto& row: configs) {
       // recreate config file with updated content
+      int lineLen;
       if (row[0].length() >= 5 && row[0].compare(row[0].length() - 5, 5, "_Pass") == 0)
         // replace passwords with asterisks
-        snprintf(configLine, FILE_NAME_LEN + 100, "%s%c%.*s%c%s%c%s%c%s\n", row[0].c_str(), DELIM, row[1].length(), FILLSTAR, DELIM, row[2].c_str(), DELIM, row[3].c_str(), DELIM, row[4].c_str());
-      else snprintf(configLine, FILE_NAME_LEN + 100, "%s%c%s%c%s%c%s%c%s\n", row[0].c_str(), DELIM, row[1].c_str(), DELIM, row[2].c_str(), DELIM, row[3].c_str(), DELIM, row[4].c_str());
-      file.write((uint8_t*)configLine, strlen(configLine));
+        lineLen = snprintf(configLine, FILE_NAME_LEN + 100, "%s%c%.*s%c%s%c%s%c%s\n", row[0].c_str(), DELIM, row[1].length(), FILLSTAR, DELIM, row[2].c_str(), DELIM, row[3].c_str(), DELIM, row[4].c_str());
+      else lineLen = snprintf(configLine, FILE_NAME_LEN + 100, "%s%c%s%c%s%c%s%c%s\n", row[0].c_str(), DELIM, row[1].c_str(), DELIM, row[2].c_str(), DELIM, row[3].c_str(), DELIM, row[4].c_str());
+      if (lineLen < 0) lineLen = 0; // Prevent write underflow crash if snprintf fails
+      if (lineLen > FILE_NAME_LEN + 100 - 1) lineLen = FILE_NAME_LEN + 100 - 1; // Prevent out-of-bounds write from snprintf truncation return
+      file.write((uint8_t*)configLine, lineLen);
       cfgCnt++;
     }
     LOG_ALT("Config file saved %d entries", cfgCnt);
@@ -509,14 +512,23 @@ static bool checkConfigFile() {
       }
       sprintf(hostName, "%s_%012llX", APP_NAME, ESP.getEfuseMac());
       char cfg[100];
-      sprintf(cfg, "appId~%s~99~~na\n", APP_NAME);
-      file.write((uint8_t*)cfg, strlen(cfg));
-      sprintf(cfg, "hostName~%s~%d~T~Device host name\n", hostName, HOSTNAME_GRP);
-      file.write((uint8_t*)cfg, strlen(cfg));
-      sprintf(cfg, "AP_SSID~%s~0~T~AP SSID name\n", hostName);
-      file.write((uint8_t*)cfg, strlen(cfg));
-      sprintf(cfg, "cfgVer~%u~99~T~na\n", CFG_VER);
-      file.write((uint8_t*)cfg, strlen(cfg));
+      int cfgLen;
+      cfgLen = snprintf(cfg, 100, "appId~%s~99~~na\n", APP_NAME);
+      if (cfgLen < 0) cfgLen = 0;
+      if (cfgLen > 100 - 1) cfgLen = 100 - 1;
+      file.write((uint8_t*)cfg, cfgLen);
+      cfgLen = snprintf(cfg, 100, "hostName~%s~%d~T~Device host name\n", hostName, HOSTNAME_GRP);
+      if (cfgLen < 0) cfgLen = 0;
+      if (cfgLen > 100 - 1) cfgLen = 100 - 1;
+      file.write((uint8_t*)cfg, cfgLen);
+      cfgLen = snprintf(cfg, 100, "AP_SSID~%s~0~T~AP SSID name\n", hostName);
+      if (cfgLen < 0) cfgLen = 0;
+      if (cfgLen > 100 - 1) cfgLen = 100 - 1;
+      file.write((uint8_t*)cfg, cfgLen);
+      cfgLen = snprintf(cfg, 100, "cfgVer~%u~99~T~na\n", CFG_VER);
+      if (cfgLen < 0) cfgLen = 0;
+      if (cfgLen > 100 - 1) cfgLen = 100 - 1;
+      file.write((uint8_t*)cfg, cfgLen);
       file.close();
       LOG_INF("Created %s from local store", CONFIG_FILE_PATH);
       return true;

--- a/webServer.cpp
+++ b/webServer.cpp
@@ -328,13 +328,13 @@ bool parseJson(int rxSize) {
 static esp_err_t sseHandler(httpd_req_t *req) {
   if (!checkAuth(req)) return ESP_OK;
   // enable Server Sent Events
-  const char* sseHeader = "HTTP/1.1 200 OK\r\n"
+  const char sseHeader[] = "HTTP/1.1 200 OK\r\n"
                           "Cache-Control: no-store\r\n"
                           "Connection: keep-alive\r\n"
                           "Content-Type: text/event-stream\r\n\r\n";
   sseSocketHD = req->handle;
   sseSocketFD = httpd_req_to_sockfd(req);
-  httpd_socket_send(sseSocketHD, sseSocketFD, sseHeader, strlen(sseHeader), 0);
+  httpd_socket_send(sseSocketHD, sseSocketFD, sseHeader, sizeof(sseHeader) - 1, 0);
   sendSSE("open", "opened");
   return ESP_OK;
 }
@@ -344,8 +344,10 @@ void sendSSE(const char* eventType, const char* eventData) {
   // send event data to browser
   if (sseSocketFD > 0) {
     char eventMsg[30];
-    snprintf(eventMsg, 30 - 1, "event: %s\ndata: ", eventType);
-    int res = httpd_socket_send(sseSocketHD, sseSocketFD, eventMsg, strlen(eventMsg), 0);
+    int msgLen = snprintf(eventMsg, 30, "event: %s\ndata: ", eventType);
+    if (msgLen < 0) msgLen = 0;
+    if (msgLen > 29) msgLen = 29;
+    int res = httpd_socket_send(sseSocketHD, sseSocketFD, eventMsg, msgLen, 0);
     res = httpd_socket_send(sseSocketHD, sseSocketFD, eventData, strlen(eventData), 0);
     res = httpd_socket_send(sseSocketHD, sseSocketFD, SSESEP, (sizeof(SSESEP) - 1), 0);
     if (res == HTTPD_SOCK_ERR_TIMEOUT) LOG_WRN("Timeout/interrupted while using socket");


### PR DESCRIPTION
💡 **What:** 
Replaced redundant `strlen()` calls evaluated immediately after string formatting by capturing the return value of `snprintf()` and `sprintf()` in `prefs.cpp` and `webServer.cpp`. Also changed the literal string pointer `sseHeader` to a char array to allow compile-time `sizeof` evaluation, and cached `strlen(payload)` inside `mqtt.cpp` to prevent calling it twice. 

🎯 **Why:**
Calling `strlen()` to find the end of a string buffer immediately after writing to it is wasteful, since the formatting functions natively return the length of the string written. Repeated O(N) evaluations add unnecessary performance overhead, especially in loops configuring settings or parsing networks requests.

📊 **Impact:**
Reduces redundant memory traversals in string manipulation paths.

🔬 **Measurement:**
- Local unit tests pass cleanly without triggering out-of-bounds reads/writes (`g++ -o test_mock_bin test_mock.cpp && ./test_mock_bin`).
- C++ compilation syntactically sound.

---
*PR created automatically by Jules for task [9654572805553712479](https://jules.google.com/task/9654572805553712479) started by @ManupaKDU*