### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to Camera Hub buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-06-26 - Native Tooltips for Range Inputs
 **Learning:** Native `title` tooltips on `<input type="range">` elements (like Brightness, Contrast, Saturation) provide an immediate, accessible way to explain the purpose of icon-heavy or context-dependent sliders without requiring additional screen space or custom JS tooltip components.
 **Action:** When adding missing tooltips to a cluster of related inputs, use Python byte-string replacement for multi-line HTML files to avoid newline issues and accurately target specific ID attributes, ensuring all inputs in a logical grouping receive consistent labeling.
+## 2024-07-17 - Added Tooltips and Screen Reader Labels to Camera Hub Buttons
+**Learning:** Native HTML buttons in the `#DeviceHub` component (Add IP, Delete All, Refresh) used brief, ambiguous text labels (like "Delete All") which lack context for screen reader users and don't provide tooltips for sighted users.
+**Action:** Always verify that interactive elements, especially those with generic text or icons, include descriptive `aria-label` and native `title` attributes to improve accessibility and discoverability without requiring custom CSS or heavy UI changes.

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1726,9 +1726,9 @@
         <!-- Input field for users to enter individual IPs -->
         <label for="ipInput">Enter IP address:&nbsp;</label>
         <input type="text" id="ipInput" class="local" placeholder="e.g. 192.168.1.100">
-        <button id="addIpButton" class="local" onclick="addIP()">Add IP</button>
-        <button id="clearStorageButton" class="local" onclick="clearLocalStorage()">Delete All</button>
-        <button id="refreshAllButton" class="local" onclick="refreshAllContainers(true)">Refresh</button>
+        <button id="addIpButton" class="local" onclick="addIP()" aria-label="Add entered IP address to Camera Hub" title="Add IP">Add IP</button>
+        <button id="clearStorageButton" class="local" onclick="clearLocalStorage()" aria-label="Delete all saved camera IP addresses" title="Delete All saved IPs">Delete All</button>
+        <button id="refreshAllButton" class="local" onclick="refreshAllContainers(true)" aria-label="Refresh all camera images" title="Refresh all images">Refresh</button>
       </div>
       <!-- Container to hold the image elements -->
       <div id="imageContainer"></div>


### PR DESCRIPTION
**💡 What**
Added descriptive `aria-label` and `title` attributes to the buttons (Add IP, Delete All, Refresh) in the Camera Hub (`#DeviceHub`) panel.

**🎯 Why**
The text on these buttons, especially "Delete All", is brief and can be ambiguous without context. The `title` attributes provide helpful native tooltips for mouse users, and the `aria-label` attributes provide full context for screen reader users (e.g., "Delete all saved camera IP addresses" instead of just "Delete All").

**📸 Before/After**
*   **Before:** Hovering over "Delete All" did nothing. Screen readers only read "Delete All button".
*   **After:** Hovering over "Delete All" shows a tooltip: "Delete All saved IPs". Screen readers read "Delete all saved camera IP addresses button".

**♿ Accessibility**
Improves keyboard and screen reader accessibility by providing descriptive context for interactive elements that were previously relying solely on short, ambiguous visual text.

---
*PR created automatically by Jules for task [4074171176066884871](https://jules.google.com/task/4074171176066884871) started by @ManupaKDU*