### PR TITLE
🧹 [code health improvement] Remove unused listBuff function

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -159,7 +159,6 @@ bool handleWebDav(httpd_req_t* rreq);
 void initStatus(int cfgGroup, int delayVal);
 void killSocket(int skt = -99);
 bool getJsonValue(const char* json, const char* key, char* value, const char* nestedKey = nullptr, int occurrence = 1);
-void listBuff(const uint8_t* b, size_t len);
 bool listDir(const char* fname, char* jsonBuff, size_t jsonBuffLen, const char* extension);
 void loadCerts();
 bool loadConfig();

--- a/utils.cpp
+++ b/utils.cpp
@@ -776,17 +776,6 @@ void urlDecode(char* inVal) {
   *writePtr = '\0';
 }
 
-void listBuff (const uint8_t* b, size_t len) {
-  // output buffer content as hex, 16 bytes per line
-  if (!len || !b) LOG_WRN("Nothing to print");
-  else {
-    for (size_t i = 0; i < len; i += 16) {
-      int linelen = (len - i) < 16 ? (len - i) : 16;
-      for (size_t k = 0; k < linelen; k++) LOG_SEND(" %02x", b[i+k]);
-      puts(" ");
-    }
-  }
-}
 
 size_t isSubArray(uint8_t* haystack, uint8_t* needle, size_t hSize, size_t nSize) {
   // find a subarray (needle) in another array (haystack)


### PR DESCRIPTION
🎯 **What:** Removed the unused `listBuff` helper function from `utils.cpp` and its declaration from `globals.h`.
💡 **Why:** `listBuff` was an unreferenced dead code function used to output buffer content as hex. Removing it improves codebase maintainability and readability by eliminating unnecessary dead code.
✅ **Verification:** Ran `git diff` to ensure only the function definition and declaration were removed without syntax errors. Verified the C++ mock tests using `g++ -o test_mock_bin test_mock.cpp && ./test_mock_bin` and confirmed they passed successfully. Also ran `pytest test_playwright.py` to make sure there are no other regressions.
✨ **Result:** Cleaned up unused dead code, reducing codebase bloat and improving code health.

---
*PR created automatically by Jules for task [5253001015830615865](https://jules.google.com/task/5253001015830615865) started by @ManupaKDU*