### PR TITLE
🔒 Fix unbounded string copy for file paths

### DIFF
--- a/utilsFS.cpp
+++ b/utilsFS.cpp
@@ -330,7 +330,7 @@ void deleteFolderOrFile(const char* deleteThis) {
     File file = df.openNextFile();
     while (file) {
       char filepath[FILE_NAME_LEN];
-      strcpy(filepath, file.path()); 
+      snprintf(filepath, sizeof(filepath), "%s", file.path());
       if (file.isDirectory()) LOG_INF("  DIR : %s", filepath);
       else {
         size_t fSize = file.size();


### PR DESCRIPTION
🎯 What: Replaced unbounded strcpy with bounded snprintf for file paths in utilsFS.cpp.
⚠️ Risk: Unbounded string copying using strcpy can lead to buffer overflow if the source string exceeds the destination buffer size.
🛡️ Solution: snprintf restricts the amount of data written to the buffer size, mitigating the buffer overflow vulnerability.

---
*PR created automatically by Jules for task [6465065162883111751](https://jules.google.com/task/6465065162883111751) started by @ManupaKDU*