### PR TITLE
🧹 Remove unused trim function

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -207,7 +207,6 @@ bool startWebServer();
 void stopPing();
 void syncToBrowser(uint32_t browserUTC);
 char* toCase(char *s, bool toLower = true);
-char* trim(char* str);
 bool updateConfigVect(const char* variable, const char* value);
 void updateStatus(const char* variable, const char* _value, bool fromUser = true);
 esp_err_t uploadHandler(httpd_req_t *req);

--- a/utils.cpp
+++ b/utils.cpp
@@ -838,24 +838,6 @@ char* fmtSize (uint64_t sizeVal) {
   return returnStr;
 }
 
-char* trim(char* str) {
-  // trim whitespace around string
-    char* start = str;
-    char* end;
-    // Trim leading whitespace
-    while (*start && isspace((unsigned char)*start)) start++;
-    if (*start == '\0') {
-        *str = '\0';
-        return str;
-    }
-    // Trim trailing whitespace
-    end = start + strlen(start) - 1;
-    while (end > start && isspace((unsigned char)*end)) end--;
-    *(end + 1) = '\0';
-    // Shift string back to original buffer if needed
-    if (start != str) memmove(str, start, end - start + 2);
-    return str;
-}
 
 char* toCase(char *s, bool toLower) {
   // convert supplied string to lower or upper case


### PR DESCRIPTION
🎯 **What:** Removed the unused `trim` function from `utils.cpp` and its declaration from `globals.h`.
💡 **Why:** The function was unreferenced anywhere in the codebase. Removing it constitutes dead code elimination, which reduces clutter and slightly improves code maintainability and compilation time.
✅ **Verification:** Verified by compiling the C++ mock tests (`g++ test_mock.cpp -o test_mock_bin && ./test_mock_bin`) and running the Playwright tests (`python test_playwright.py`) locally, ensuring both test suites complete successfully without errors. A global codebase search (`grep -rn "trim"`) confirmed no active references existed before removal.
✨ **Result:** A cleaner codebase with the dead code fully removed.

---
*PR created automatically by Jules for task [6485282197057976116](https://jules.google.com/task/6485282197057976116) started by @ManupaKDU*