### PR TITLE
🧹 Remove unused `toCase` function

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -206,7 +206,6 @@ bool startStorage();
 bool startWebServer();
 void stopPing();
 void syncToBrowser(uint32_t browserUTC);
-char* toCase(char *s, bool toLower = true);
 char* trim(char* str);
 bool updateConfigVect(const char* variable, const char* value);
 void updateStatus(const char* variable, const char* _value, bool fromUser = true);

--- a/utils.cpp
+++ b/utils.cpp
@@ -857,12 +857,6 @@ char* trim(char* str) {
     return str;
 }
 
-char* toCase(char *s, bool toLower) {
-  // convert supplied string to lower or upper case
-  for (char *p = s; *p; ++p) *p = toLower ? (char)tolower((unsigned char)*p) : (char)toupper((unsigned char)*p);
-  return s;
-}
-
 /********************** analog functions ************************/
 
 uint16_t smoothAnalog(int analogPin, int samples) {


### PR DESCRIPTION
🎯 **What:**
Removed the unused `toCase` function definition from `utils.cpp` and its declaration from `globals.h`.

💡 **Why:**
The function was an unreferenced helper, meaning it was dead code. Removing it improves codebase maintainability, reduces clutter, and helps streamline code comprehension.

✅ **Verification:**
1. Ran `grep -rnw . -e "toCase"` to verify the function is no longer present.
2. Compiled and ran the C++ test suite (`test_mock.cpp`) locally and ensured it passed successfully.
3. Installed Playwright and its dependencies, and successfully ran the Python test suite (`test_playwright.py`) to catch regressions.

✨ **Result:**
A cleaner codebase with dead code eliminated, lowering maintenance overhead.

---
*PR created automatically by Jules for task [13492591146574807494](https://jules.google.com/task/13492591146574807494) started by @ManupaKDU*