### PR TITLE
🧹 Remove unused getFileDate function from utilsFS

### DIFF
--- a/utilsFS.cpp
+++ b/utilsFS.cpp
@@ -172,14 +172,6 @@ static void getOldestDir(char* oldestDir) {
   }
 }
 
-void inline getFileDate(File& file, char* fileDate) {
-  // get last write date of file as string
-  time_t writeTime = file.getLastWrite();
-  struct tm lt;
-  localtime_r(&writeTime, &lt);
-  strftime(fileDate, strlen(fileDate), "%Y-%m-%d %H:%M:%S", &lt);
-}
-
 bool checkFreeStorage() { 
   // Check for sufficient space on storage
   bool res = false;


### PR DESCRIPTION
🎯 **What:** Removed the unreferenced `getFileDate` helper function from `utilsFS.cpp`.
💡 **Why:** This removes dead code, which cleans up the file and slightly improves maintainability by reducing unused clutter.
✅ **Verification:** Verified the code compiles by running the C++ `test_mock_bin` suite. Verified frontend tests continue to pass via `pytest test_playwright.py`. Code review confirmed it as a safe dead code elimination.
✨ **Result:** A cleaner `utilsFS.cpp` with no change to existing functionality.

---
*PR created automatically by Jules for task [6465065162883112254](https://jules.google.com/task/6465065162883112254) started by @ManupaKDU*