### PR TITLE
🧹 [Remove redundant dTime assignments in checkMotion]

### DIFF
--- a/motionDetect.cpp
+++ b/motionDetect.cpp
@@ -321,7 +321,6 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
     }
   } else {
     // normal motion detection
-    dTime = millis();
     if (!nightTime && changeCount > moveThreshold) {
       LOG_VRB("### Change detected");
       motionCnt++; // number of consecutive changes
@@ -336,7 +335,6 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
           motionStatus = false;
         }
 #endif
-        dTime = millis();
 #if INCLUDE_MQTT
         if (mqtt_active && motionCnt) {
           snprintf(jsonBuff, JSON_BUFF_LEN, "{\"MOTION\":\"ON\",\"TIME\":\"%s\"}", esp_log_system_timestamp());


### PR DESCRIPTION
🎯 **What:** Removed unused and redundant assignments to `dTime` in `motionDetect.cpp` at lines 324 and 339.
💡 **Why:** To improve code health by removing isolated and redundant assignments that are never read afterwards, thereby reducing code clutter and confusion.
✅ **Verification:** Verified by checking the scope of `dTime` usages and running the relevant test suites (like `test_mock_bin` and Playwright tests).
✨ **Result:** Improved code maintainability by reducing dead code and confusion.

---
*PR created automatically by Jules for task [2364896603241290781](https://jules.google.com/task/2364896603241290781) started by @ManupaKDU*