### PR TITLE
🧹 [code health improvement] Remove unused setupADC function

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -195,7 +195,6 @@ esp_err_t sendChunks(File df, httpd_req_t *req, bool endChunking = true);
 void sendSSE(const char* eventType, const char* eventData);
 void setFolderName(const char* fname, char* fileName);
 void setPeripheralResponse(const byte pinNum, const uint32_t responseData);
-void setupADC();
 void showProgress(const char* marker = ".");
 void showSys();
 uint16_t smoothAnalog(int analogPin, int samples = ADC_SAMPLES);

--- a/peripherals.cpp
+++ b/peripherals.cpp
@@ -750,7 +750,8 @@ static void prepLedBar() {
 
 void prepPeripherals() {
   // initial setup of each peripheral on client or extender
-  setupADC();
+  analogSetAttenuation(ADC_ATTEN);
+  analogReadResolution(ADC_BITS);
   setupBatt();
   setupLamp();
   prepPIR();

--- a/utils.cpp
+++ b/utils.cpp
@@ -875,11 +875,6 @@ uint16_t smoothAnalog(int analogPin, int samples) {
   return level;
 }
 
-void setupADC() {
-  analogSetAttenuation(ADC_ATTEN);
-  analogReadResolution(ADC_BITS);
-}
-
 float smoothSensor(float latestVal, float smoothedVal, float alpha) {
   // simple Exponential Moving Average filter 
   // where alpha between 0.0 (max smooth) and 1.0 (no smooth)


### PR DESCRIPTION
🎯 **What:** Removed the `setupADC` helper function from `utils.cpp` and its declaration from `globals.h`. The function's logic was inlined into its single caller in `peripherals.cpp`.

💡 **Why:** `setupADC` was an unnecessary abstraction for only two lines of code that are called exactly once. Removing it eliminates a layer of indirection and cleans up the global namespace, improving code readability and maintainability.

✅ **Verification:** Verified by compiling and running the C++ test suite and the Python Playwright test suite to ensure no regressions were introduced. The application's behavior is perfectly preserved as the underlying ADC setup calls are still executed during peripheral preparation.

✨ **Result:** A cleaner codebase with less dead code/unnecessary abstractions, while retaining full functionality.

---
*PR created automatically by Jules for task [1525830640632770954](https://jules.google.com/task/1525830640632770954) started by @ManupaKDU*