### PR TITLE
🧹 [code health] Remove unread httpCode variable assignments

### DIFF
--- a/appSpecific.cpp
+++ b/appSpecific.cpp
@@ -656,11 +656,10 @@ void getNocturnal() {
     NetworkClientSecure hclient;
     if (remoteServerConnect(hclient, EXT_NOCT_HOST, HTTPS_PORT, "", GETEXTNOCT)) {
       HTTPClient http;
-      int httpCode = HTTP_CODE_NOT_FOUND;
       char extNoctPath[100];
       snprintf(extNoctPath, sizeof(extNoctPath), EXT_NOCT_PATH, latLon[0], latLon[1]);
       if (http.begin(hclient, EXT_NOCT_HOST, HTTPS_PORT, extNoctPath)) {
-        httpCode = http.GET();
+        int httpCode = http.GET();
         if (httpCode == HTTP_CODE_OK) {
           String payload = http.getString();
           char jsonVal[FILE_NAME_LEN] = "";

--- a/externalHeartbeat.cpp
+++ b/externalHeartbeat.cpp
@@ -6,43 +6,42 @@
 #if INCLUDE_EXTHB
 
 // External Heartbeat
-char external_heartbeat_domain[MAX_HOST_LEN] = "";  //External Heartbeat domain/IP  
+char external_heartbeat_domain[MAX_HOST_LEN] = "";  //External Heartbeat domain/IP
 char external_heartbeat_uri[64] = "";     //External Heartbeat uri (i.e. /myesp32-cam-hub/index.php)
-int external_heartbeat_port;              //External Heartbeat server port to connect.  
-char external_heartbeat_token[EXTHB_LEN] = "";   //External Heartbeat server username.  
+int external_heartbeat_port;              //External Heartbeat server port to connect.
+char external_heartbeat_token[EXTHB_LEN] = "";   //External Heartbeat server username.
 
 bool external_heartbeat_active = false;
 
 void sendExternalHeartbeat() {
-  
+
   // external_heartbeat_active~0~2~C~External Heartbeat Server enabled
   // external_heartbeat_domain~~2~T~Heartbeat receiver domain or IP (i.e. www.mydomain.com)
   // external_heartbeat_uri~~2~T~Heartbeat receiver URI (i.e. /my-esp32cam-hub/index.php)
   // external_heartbeat_port~443~2~N~Heartbeat receiver port
   // external_heartbeat_token~~2~T~Heartbeat receiver auth token
-  
+
   // POST to external heartbeat address
   char uri[64 + 10 + EXTHB_LEN] = "";
   strcpy(uri, external_heartbeat_uri);
   strcat(uri, "?token=");
   strcat(uri, external_heartbeat_token);
-  
+
   NetworkClientSecure hclient;
-  
+
   buildJsonString(false);
 
   if (remoteServerConnect(hclient, external_heartbeat_domain, external_heartbeat_port, "", EXTERNALHB)) {
     HTTPClient https;
-    int httpCode = HTTP_CODE_NOT_FOUND;
     if (https.begin(hclient, external_heartbeat_domain, external_heartbeat_port, uri)) {
 
       https.addHeader("Content-Type", "application/json");
-      
-      httpCode = https.POST(jsonBuff);
+
+      int httpCode = https.POST(jsonBuff);
       if (httpCode == HTTP_CODE_OK) {
         LOG_INF("External Heartbeat sent to: %s%s", external_heartbeat_domain, uri);
       } else LOG_WRN("External Heartbeat request failed, error: %s", https.errorToString(httpCode).c_str());
-      https.end();     
+      https.end();
     }
     remoteServerClose(hclient);
   }

--- a/periphsI2C.cpp
+++ b/periphsI2C.cpp
@@ -265,11 +265,10 @@ static float getSeaLevelPressure() {
   char jsonVal[FILE_NAME_LEN] = "";
   if (remoteServerConnect(hclient, EXT_MSL_HOST, HTTP_PORT, GETEXTMSL)) {
     HTTPClient http;
-    int httpCode = HTTP_CODE_NOT_FOUND;
     char extMslPath[100];
     snprintf(extMslPath, sizeof(extMslPath), EXT_MSL_PATH, latLon[0], latLon[1]);
     if (http.begin(hclient, EXT_MSL_HOST, HTTP_PORT, extMslPath)) {
-      httpCode = http.GET();
+      int httpCode = http.GET();
       if (httpCode == HTTP_CODE_OK) {
         String payload = http.getString();
         if (!getJsonValue(payload.c_str(), "pressure_msl", jsonVal, nullptr, 2)) LOG_WRN("'pressure_msl' field not present");
@@ -455,11 +454,10 @@ static float getMagneticDeclination() {
   float angle = 0.0f;
   if (remoteServerConnect(hclient, EXT_MAG_HOST, HTTP_PORT, GETEXTMAG)) {
     HTTPClient http;
-    int httpCode = HTTP_CODE_NOT_FOUND;
     char extMagPath[100];
     snprintf(extMagPath, sizeof(extMagPath), EXT_MAG_PATH, latLon[0], latLon[1]);
     if (http.begin(hclient, EXT_MAG_HOST, HTTP_PORT, extMagPath)) {
-      httpCode = http.GET();
+      int httpCode = http.GET();
       if (httpCode == HTTP_CODE_OK) {
         String payload = http.getString();
         if (getJsonValue(payload.c_str(), "declination", jsonVal, "value")) {

--- a/utils.cpp
+++ b/utils.cpp
@@ -528,9 +528,8 @@ void getExtIP() {
     NetworkClient hclient;
     if (remoteServerConnect(hclient, EXT_IP_HOST, HTTP_PORT, GETEXTIP)) {
       HTTPClient http;
-      int httpCode = HTTP_CODE_NOT_FOUND;
       if (http.begin(hclient, EXT_IP_HOST, HTTP_PORT, EXT_IP_PATH)) {
-        httpCode = http.GET();
+        int httpCode = http.GET();
         if (httpCode == HTTP_CODE_OK) {
           String payload = http.getString();
           char jsonVal[FILE_NAME_LEN] = "";


### PR DESCRIPTION
🎯 **What:** Removed unused and unread initializations of the `httpCode` variable across multiple files (`appSpecific.cpp`, `externalHeartbeat.cpp`, `periphsI2C.cpp`, `utils.cpp`). The variable is now declared directly inside the `if` block where its assigned value is read.
💡 **Why:** Static analysis flags variables that are assigned a value but never read as code smells. By moving the declaration to where it is used, we eliminate dead stores, limit the variable's scope, and improve overall maintainability.
✅ **Verification:**
1. Ran `git diff` to ensure changes cleanly scoped the `httpCode` variables.
2. Compiled and ran C++ tests using `g++ -o test_mock_bin test_mock.cpp && ./test_mock_bin`.
3. Ran Python Playwright tests to ensure no regressions were introduced.
4. Cleaned up all binary and cache artifacts before committing.
✨ **Result:** Cleaned up five instances of unread variable assignments, improving static analysis scores and code clarity without affecting functionality.

---
*PR created automatically by Jules for task [16072625849860984549](https://jules.google.com/task/16072625849860984549) started by @ManupaKDU*