### PR TITLE
🧹 [Code Health] Remove unused formatHex helper function

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -144,7 +144,6 @@ esp_err_t fileHandler(httpd_req_t* req, bool download = false);
 void flush_log(bool andClose = false);
 char* fmtSize (uint64_t sizeVal);
 void formatElapsedTime(char* timeStr, uint32_t timeVal, bool noDays = false);
-void formatHex(const char* inData, size_t inLen);
 const char* formatIPstr(bool getAP = false);
 bool formatSDcard();
 bool fsStartTransfer(const char* fileFolder);

--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -192,14 +192,6 @@ int vprintfRedirect(const char* format, va_list args) {
   return len;
 }
 
-void formatHex(const char* inData, size_t inLen) {
-  // format data as hex bytes for output
-  char formatted[(inLen * 3) + 1];
-  for (int i=0; i<inLen; i++) sprintf(formatted + (i*3), "%02x ", inData[i]);
-  formatted[(inLen * 3)] = 0; // terminator
-  LOG_INF("Hex: %s", formatted);
-}
-
 const char* espErrMsg(esp_err_t errCode) {
   // convert esp error code to text
   // https://github.com/espressif/esp-idf/blob/master/components/esp_common/include/esp_err.h


### PR DESCRIPTION
🎯 **What:** Removed the unreferenced `formatHex` helper function definition from `utilsLog.cpp` and its declaration from `globals.h`.

💡 **Why:** Removing dead code improves code maintainability, reduces confusion for future contributors, and slightly reduces the compiled footprint.

✅ **Verification:** Verified clean removal via `git diff`. Executed C++ mock tests (`test_mock`) and Python frontend tests (`test_playwright.py`) to ensure no regressions were introduced. Both passed successfully.

✨ **Result:** A cleaner `utilsLog.cpp` and `globals.h` without unused dead code.

---
*PR created automatically by Jules for task [7487822699594114322](https://jules.google.com/task/7487822699594114322) started by @ManupaKDU*