### PR TITLE
🧹 [code health improvement: Remove unused assignments to mTime]

### DIFF
--- a/mjpeg2sd.cpp
+++ b/mjpeg2sd.cpp
@@ -617,12 +617,11 @@ mjpegStruct getNextFrame(bool firstCall) {
   }
   LOG_VRB("http send time %lu ms", millis() - hTime);
   hTimeTot += millis() - hTime;
-  uint32_t mTime = millis();
   if (!stopPlayback) {
     // continue sending out frames
     if (!remainingBuff) {
       // load more data from SD
-      mTime = millis();
+      uint32_t mTime = millis();
       // move final bytes to buffer start in case jpeg marker at end of buffer
       memcpy(iSDbuffer, iSDbuffer + RAMSIZE, CHUNK_HDR);
       xSemaphoreTake(readSemaphore, portMAX_DELAY); // wait for read from SD card completed
@@ -639,7 +638,6 @@ mjpegStruct getNextFrame(bool firstCall) {
       else buffOffset = frameCnt ? 0 : CHUNK_HDR; // only before 1st frame
       xTaskNotifyGive(playbackHandle); // wake up task to get next cluster - sets readLen
     }
-    mTime = millis();
     if (!remainingFrame) {
       // at start of jpeg frame marker
       uint32_t inVal;
@@ -659,7 +657,7 @@ mjpegStruct getNextFrame(bool firstCall) {
         vidSize += jpegSize;
         buffOffset += CHUNK_HDR; // skip over marker
         mjpegData.jpegSize = jpegSize; // signal start of jpeg to webServer
-        mTime = millis();
+        uint32_t mTime = millis();
         // wait on playbackSemaphore for rate control
         xSemaphoreTake(playbackSemaphore, portMAX_DELAY);
         LOG_VRB("frame timer wait %lu ms", millis() - mTime);


### PR DESCRIPTION
🎯 **What:** Addressed a code health issue where the `mTime` variable was assigned values that were frequently overwritten or never read, resulting in static analysis warnings.
💡 **Why:** Overarching variable declarations that are indiscriminately reassigned throughout a function create dead code and make it harder to trace the true flow of data. Restricting `mTime` to block-level scope where it is genuinely used (for semaphore timing logs) eliminates dead assignments and improves code hygiene.
✅ **Verification:** Compiled the C++ test suite via `g++ test_mock.cpp`, passed all existing tests, and executed the Python Playwright suite without issues. Manually reviewed `git diff` to ensure no semantic logic changes were made.
✨ **Result:** Improved maintainability, narrower variable scopes, and cleaner static analysis output with no functional changes.

---
*PR created automatically by Jules for task [4204418181527621284](https://jules.google.com/task/4204418181527621284) started by @ManupaKDU*