### PR TITLE
🧹 Remove unused dummy checkPotVol function

### DIFF
--- a/appGlobals.h
+++ b/appGlobals.h
@@ -258,7 +258,6 @@ void buildAviIdx(size_t dataSize, bool isVid = true, bool isTL = false);
 size_t buildSubtitle(int srtSeqNo, uint32_t sampleInterval);
 void buzzerAlert(bool buzzerOn);
 bool checkAccelMove();
-int8_t checkPotVol(int8_t adjVol);
 bool checkSDFiles();
 void currentStackUsage();
 void displayAudioLed(int16_t audioSample);

--- a/appSpecific.cpp
+++ b/appSpecific.cpp
@@ -535,10 +535,6 @@ void displayAudioLed(int16_t audioSample) {
 void setupAudioLed() {
 }
 
-int8_t checkPotVol(int8_t adjVol) {
-  return adjVol; // dummy
-}
-
 void applyFilters() {
   applyVolume();
 }

--- a/audio.cpp
+++ b/audio.cpp
@@ -103,9 +103,6 @@ static uint8_t wavHeader[WAV_HDR_LEN] = { // WAV header template
 void applyVolume() {
   // determine required volume setting
   int8_t adjVol = ampVol * 2; // use web page setting
-#ifdef ISVC
-  adjVol = checkPotVol(adjVol);  // use potentiometer setting if available
-#endif
   if (adjVol) {
     // increase or reduce volume, 6 is unity eg midpoint of pot / web slider
     adjVol = adjVol > 5 ? adjVol - 5 : adjVol - 7; 


### PR DESCRIPTION
🎯 **What:** Removed the unused dummy function `checkPotVol` from `appSpecific.cpp`, its declaration from `appGlobals.h`, and its usage from `audio.cpp`.
💡 **Why:** `checkPotVol` was just a dummy function (`return adjVol;`). Its usage in `audio.cpp` was effectively a no-op `adjVol = checkPotVol(adjVol);`. Removing this dead code simplifies the codebase, improves maintainability, and removes unnecessary clutter without changing behavior.
✅ **Verification:**
1. Ran `g++ -o test_mock_bin test_mock.cpp && ./test_mock_bin` to verify C++ code still compiles cleanly and tests pass.
2. Ran Python UI tests via Playwright locally and verified they still pass.
✨ **Result:** Cleaned up unused dummy functions and unneeded `#ifdef ISVC` block, simplifying the audio logic and overall code maintainability.

---
*PR created automatically by Jules for task [49153283964732979](https://jules.google.com/task/49153283964732979) started by @ManupaKDU*