### PR TITLE
🔒 Fix buffer overflow in strftime length argument

### DIFF
--- a/photogram.cpp
+++ b/photogram.cpp
@@ -96,7 +96,7 @@ static void getPhoto() {
     char pName[FILE_NAME_LEN];
     strcpy(pName, pFolder);
     time_t currEpoch = getEpoch();
-    strftime(pName + strlen(pFolder), sizeof(pName), "/%Y%m%d_%H%M%S", localtime(&currEpoch));
+    strftime(pName + strlen(pFolder), sizeof(pName) - strlen(pFolder), "/%Y%m%d_%H%M%S", localtime(&currEpoch));
     strcat(pName, JPG_EXT);
     File pFile = STORAGE.open(pName, FILE_WRITE);
     // save file to SD


### PR DESCRIPTION
🎯 What: Fixed a stack buffer overflow vulnerability in `photogram.cpp` where the `strftime` function was given the full buffer size `sizeof(pName)` despite writing to an offset `pName + strlen(pFolder)`.
     
⚠️ Risk: If `pFolder` is large enough, passing `sizeof(pName)` allows `strftime` to write past the end of the `pName` array, leading to a stack buffer overflow which could potentially cause a crash or be exploited to execute arbitrary code.
     
🛡️ Solution: Updated the buffer size argument passed to `strftime` to accurately reflect the remaining space in the buffer: `sizeof(pName) - strlen(pFolder)`.

---
*PR created automatically by Jules for task [16407993235641055739](https://jules.google.com/task/16407993235641055739) started by @ManupaKDU*