### PR TITLE
🧹 Remove globally unused smoothAnalog and fix its broken references

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -198,7 +198,6 @@ void setPeripheralResponse(const byte pinNum, const uint32_t responseData);
 void setupADC();
 void showProgress(const char* marker = ".");
 void showSys();
-uint16_t smoothAnalog(int analogPin, int samples = ADC_SAMPLES);
 float smoothSensor(float latestVal, float smoothedVal, float alpha);
 void startOTAtask();
 void startSecTimer(bool startTimer);

--- a/peripherals.cpp
+++ b/peripherals.cpp
@@ -5,13 +5,13 @@
 // - DS18B20 temperature sensor
 // - battery voltage measurement
 // - lamp LED driver (PWM or WS2812 / SK6812)
-// - 3 pin joystick 
+// - 3 pin joystick
 // - MY9221 based LED Bar, eg 10 segment Grove LED Bar
 // - 5 wire 28BYJ-48 Unipolar Stepper Motor with ULN2003 Motor Driver
 // - 4 wire Bipolar Stepper Motor with MX1508 H-Bridge Motor Driver
 //
 // Peripherals can be hosted directly on the client ESP, or on
-// a separate IO Extender ESP if the client ESP has limited free 
+// a separate IO Extender ESP if the client ESP has limited free
 // pins, eg ESP-Cam module
 // External peripherals should have low data rate and not require fast response,
 // so interrupt driven input pins should be monitored internally by the client.
@@ -27,10 +27,20 @@
 #if INCLUDE_PERIPH
 #include "driver/ledc.h"
 
+static uint16_t smoothAnalog(int analogPin, int samples = ADC_SAMPLES) {
+  // get averaged analog pin value
+  uint32_t level = 0;
+  if (analogPin > 0) {
+    for (int j = 0; j < samples; j++) level += analogRead(analogPin);
+    level /= samples;
+  }
+  return level;
+}
+
 // peripherals used
 bool pirUse; // true to use PIR for motion detection
 bool ledBarUse; // true to use led bar
-uint8_t lampLevel; // brightness of on board lamp led 
+uint8_t lampLevel; // brightness of on board lamp led
 bool lampAuto = false; // if true in conjunction with pirUse and accelUse, switch on lamp when PIR or accelerometer activated at night
 bool lampNight; // if true, lamp comes on at night (not used)
 int lampType; // how lamp is used
@@ -44,21 +54,21 @@ bool RCactive = false;
 
 // Pins used by peripherals
 
-// sensors 
+// sensors
 int pirPin; // if pirUse is true
 int lampPin;
 int buzzerPin; // if buzzerUse is true
 
-// Camera servos 
+// Camera servos
 int servoPanPin;
 int servoTiltPin;
 
-// ambient / module temperature reading 
+// ambient / module temperature reading
 int ds18b20Pin; // if INCLUDE_DS18B20 true
 
-// batt monitoring 
+// batt monitoring
 // only pin 33 can be used on ESP32-Cam module as it is the only available analog pin
-int voltPin; 
+int voltPin;
 
 // additional peripheral configuration
 // configure for specific servo model, eg for SG90
@@ -67,7 +77,7 @@ int servoMaxAngle;
 int servoMinPulseWidth; // usecs
 int servoMaxPulseWidth;
 int servoDelay; // control rate of change of servo angle using delay
-int servoCenter = 90; // angle in degrees where servo is centered 
+int servoCenter = 90; // angle in degrees where servo is centered
 
 // configure battery monitor
 int voltDivider; // set battVoltageDivider value to be divisor of input voltage from resistor divider
@@ -76,7 +86,7 @@ float voltLow; // voltage level at which to send out email alert
 int voltInterval; // interval in minutes to check battery voltage
 
 // buzzer duration
-int buzzerDuration; // time buzzer sounds in seconds 
+int buzzerDuration; // time buzzer sounds in seconds
 
 // RC pins and control
 int servoSteerPin;
@@ -88,7 +98,7 @@ int minDutyCycle;
 int maxTurnSpeed;
 bool allowReverse;
 bool autoControl;
-int waitTime; 
+int waitTime;
 int stickzPushPin; // digital pin connected to switch output
 int stickXpin; // analog pin connected to X output
 int stickYpin; // analog pin connected to Y output
@@ -100,7 +110,7 @@ int ledBarClock;
 int ledBarData;
 
 // Stepper motor driver pins
-#define stepperPins 4 
+#define stepperPins 4
 uint8_t stepINpins[stepperPins];
 
 static void doStep();
@@ -111,8 +121,8 @@ void setLamp(uint8_t lampVal);
 // individual pin sensor / controller functions
 
 bool getPIRval() {
-  // get PIR or radar sensor status 
-  return digitalRead(pirPin); 
+  // get PIR or radar sensor status
+  return digitalRead(pirPin);
 }
 
 void buzzerAlert(bool buzzerOn) {
@@ -121,7 +131,7 @@ void buzzerAlert(bool buzzerOn) {
     if (buzzerOn) {
       // turn buzzer on
       pinMode(buzzerPin, OUTPUT);
-      digitalWrite(buzzerPin, HIGH); 
+      digitalWrite(buzzerPin, HIGH);
     } else digitalWrite(buzzerPin, LOW); // turn buzzer off
   }
 }
@@ -139,7 +149,7 @@ void buzzerAlert(bool buzzerOn) {
 
 TaskHandle_t servoHandle = NULL;
 static int newTiltVal, newPanVal, newSteerVal;
-static int oldPanVal, oldTiltVal, oldSteerVal; 
+static int oldPanVal, oldTiltVal, oldSteerVal;
 
 static int dutyCycle (int angle) {
   // calculate duty cycle for given angle
@@ -255,7 +265,7 @@ static void prepServos() {
 */
 
 #if INCLUDE_DS18B20
-#if __has_include("../libraries/DallasTemperature/DallasTemperature.h") 
+#if __has_include("../libraries/DallasTemperature/DallasTemperature.h")
 #include <OneWire.h> // https://github.com/PaulStoffregen/OneWire
 #include <DallasTemperature.h> // https://github.com/milesburton/Arduino-Temperature-Control-Library
 #else
@@ -281,14 +291,14 @@ static void DS18B20task(void* pvParameters) {
     if (deviceAddress[0] == 0x28) {
       uint8_t tryCnt = 10;
       while (tryCnt) {
-        sensors.requestTemperatures(); 
+        sensors.requestTemperatures();
         dsTemp = sensors.getTempCByIndex(0);
         // ignore occasional duff readings
         if (dsTemp > NULL_TEMP) tryCnt = 10;
         else tryCnt--;
         delay(1000);
-      }   
-    } 
+      }
+    }
     // retry setting up ds18b20
     delay(10000);
   }
@@ -298,7 +308,7 @@ static void DS18B20task(void* pvParameters) {
 void prepTemperature() {
 #if INCLUDE_DS18B20
   if (ds18b20Pin) {
-    xTaskCreateWithCaps(&DS18B20task, "DS18B20task", DS18B20_STACK_SIZE, NULL, DS18B20_PRI, &DS18B20handle, STACK_MEM); 
+    xTaskCreateWithCaps(&DS18B20task, "DS18B20task", DS18B20_STACK_SIZE, NULL, DS18B20_PRI, &DS18B20handle, STACK_MEM);
     haveDS18B20 = true;
     LOG_INF("Using DS18B20 sensor");
   } else LOG_WRN("No DS18B20 pin defined, using chip sensor if present");
@@ -351,7 +361,7 @@ static void battTask(void* parameter) {
 
 static void setupBatt() {
   if (voltUse) {
-  	if (voltPin) {
+	if (voltPin) {
       xTaskCreateWithCaps(&battTask, "battTask", BATT_STACK_SIZE, NULL, BATT_PRI, &battHandle, STACK_MEM);
       LOG_INF("Monitor batt voltage");
       debugMemory("setupBatt");
@@ -384,7 +394,7 @@ static void setupLamp() {
     lampInit = true;
 #if defined(USE_WS2812)
     // WS2812 RGB high intensity led
-    if (rmtInit(lampPin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000)) 
+    if (rmtInit(lampPin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000))
       LOG_INF("Setup WS2812 Lamp Led on pin %d", lampPin);
     else {
       LOG_WRN("Failed to setup WS2812 on pin %u", lampPin);
@@ -412,7 +422,7 @@ void setLamp(uint8_t lampVal) {
       for (uint8_t i = 0; i < 3; i++) {
         RGB[i] = lampVal;
         // apply WS2812 bit encoding pulse timing per bit
-        for (uint8_t j = 0; j < 8; j++) { 
+        for (uint8_t j = 0; j < 8; j++) {
           int bit = (i * 8) + j;
           if ((RGB[i] << j) & 0x80) { // get left most bit first
             // bit = 1
@@ -441,7 +451,7 @@ void setLamp(uint8_t lampVal) {
 }
 
 void twinkleLed(uint8_t ledPin, uint16_t interval, uint8_t blinks) {
-  // twinkle led, for given number of blinks, 
+  // twinkle led, for given number of blinks,
   //  with given interval in ms between blinks
   bool ledState = true;
   for (int i=0; i<blinks*2; i++) {
@@ -452,7 +462,7 @@ void twinkleLed(uint8_t ledPin, uint16_t interval, uint8_t blinks) {
 }
 
 void setLightsRC(bool lightsOn) {
-  // on / off RC light 
+  // on / off RC light
   if (lightsRCpin > 0) digitalWrite(lightsRCpin, lightsOn);
 }
 
@@ -489,7 +499,7 @@ static void IRAM_ATTR stickISR() {
   // interrupt at timer rate
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
   if (stickHandle) {
-    vTaskNotifyGiveFromISR(stickHandle, &xHigherPriorityTaskWoken); 
+    vTaskNotifyGiveFromISR(stickHandle, &xHigherPriorityTaskWoken);
     portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
   }
 }
@@ -499,7 +509,7 @@ void setStickTimer(bool restartTimer, uint32_t interval) {
   static hw_timer_t* stickTimer = NULL;
   // stop timer if running
   if (stickTimer) {
-    timerDetachInterrupt(stickTimer); 
+    timerDetachInterrupt(stickTimer);
     timerEnd(stickTimer);
     stickTimer = NULL;
   }
@@ -519,13 +529,13 @@ static void stickTask (void *pvParameter) {
       // get joystick position, adjusted for zero offset
       int xPos = smoothAnalog(stickXpin, sRate);
       int steerAngle = (xPos > CENTER_ADC + xOffset) ? map(xPos, CENTER_ADC + xOffset, MAX_ADC, servoCenter, servoCenter + maxSteerAngle)
-        : map(xPos, 0, CENTER_ADC + xOffset, servoCenter - maxSteerAngle, servoCenter); 
+        : map(xPos, 0, CENTER_ADC + xOffset, servoCenter - maxSteerAngle, servoCenter);
       setSteering(steerAngle);
-      
+
       int yPos = smoothAnalog(stickYpin, sRate);
       // reverse orientation of Y axis so up is forward
       int motorCycle = (yPos > CENTER_ADC + yOffset) ? map(yPos, CENTER_ADC + yOffset, MAX_ADC, 0, 0 - maxDutyCycle)
-        : map(yPos, 0, CENTER_ADC + yOffset, maxDutyCycle, 0); 
+        : map(yPos, 0, CENTER_ADC + yOffset, maxDutyCycle, 0);
       if (abs(motorCycle) < minDutyCycle) motorCycle = 0; // deadzone
 #if INCLUDE_MCPWM
       motorSpeed(motorCycle);
@@ -536,7 +546,7 @@ static void stickTask (void *pvParameter) {
     }
     if (stepperUse) doStep();
   }
-} 
+}
 
 static void prepJoystick() {
   if (stickUse) {
@@ -547,7 +557,7 @@ static void prepJoystick() {
       LOG_VRB("X-offset: %d, Y-offset: %d", xOffset, yOffset);
       if (stickzPushPin > 0) {
         pinMode(stickzPushPin, INPUT_PULLUP);
-        attachInterrupt(digitalPinToInterrupt(stickzPushPin), buttonISR, FALLING); 
+        attachInterrupt(digitalPinToInterrupt(stickzPushPin), buttonISR, FALLING);
       }
       if (stickHandle == NULL) xTaskCreateWithCaps(&stickTask, "stickTask", STICK_STACK_SIZE , NULL, STICK_PRI, &stickHandle, STACK_MEM);
       setStickTimer(true, waitTime * 1000);
@@ -575,15 +585,15 @@ static uint8_t modelIndex = 0;
 static uint8_t stepPhase = 0;
 static const uint8_t pinSequence[stepPhases * modelTypes][stepperPins] = {
   // 28BYJ-48 unipolar full step phases
-  {1, 1, 0, 0}, 
-  {0, 1, 1, 0}, 
-  {0, 0, 1, 1}, 
+  {1, 1, 0, 0},
+  {0, 1, 1, 0},
+  {0, 0, 1, 1},
   {1, 0, 0, 1},
   // 8mm bipolar half step phases
-  {1, 0, 1, 0}, 
-  {0, 1, 1, 0}, 
-  {0, 1, 0, 1}, 
-  {1, 0, 0, 1}, 
+  {1, 0, 1, 0},
+  {0, 1, 1, 0},
+  {0, 1, 0, 1},
+  {1, 0, 0, 1},
 };
 
 
@@ -604,9 +614,9 @@ static void prepStepper() {
         digitalWrite(stepINpins[i], LOW);
       }
       // stickTask provides speed control timer
-      if (stickHandle == NULL) xTaskCreateWithCaps(&stickTask, "stickTask", STICK_STACK_SIZE , NULL, STICK_PRI, &stickHandle, STACK_MEM);   
+      if (stickHandle == NULL) xTaskCreateWithCaps(&stickTask, "stickTask", STICK_STACK_SIZE , NULL, STICK_PRI, &stickHandle, STACK_MEM);
       LOG_INF("Stepper motor on pins: %d, %d, %d, %d", stepINpins[0], stepINpins[1], stepINpins[2], stepINpins[3]);
-      // NOTE: very first step after motor power may not occur or be reversed 
+      // NOTE: very first step after motor power may not occur or be reversed
     } else {
       stepperUse = false;
       LOG_WRN("Stepper pins not defined");
@@ -642,7 +652,7 @@ void stepperRun(float RPM, float revFraction, bool _clockwise, stepperModel this
 
 static void doStep() {
   // called from sticktask to do single step in sequence
-  if (stepsToDo > 0) { 
+  if (stepsToDo > 0) {
     stepsToDo--;
     for (int i = 0; i < stepperPins; i++) digitalWrite(stepINpins[i], pinSequence[modelIndex + stepPhase][i]);
     nextPhase();
@@ -664,7 +674,7 @@ static void doStep() {
     Red    3V3
     White  DCKI Clock pin
     Yellow D1 Data pin
-    
+
  Can be used as a gauge, eg display sound level
  */
 
@@ -678,13 +688,13 @@ static uint8_t ledLevel[LEDBAR_COUNT];
 
 static void ledBarLatch() {
   // display uploaded register by triggering internal-latch function
-  digitalWrite(ledBarClock, LOW); 
+  digitalWrite(ledBarClock, LOW);
   delayMicroseconds(250); // minimum 220us
   // Internal-latch control cycle
   bool dataVal = false;
   for (uint8_t i = 0; i < 8; i++, dataVal = !dataVal) {
     digitalWrite(ledBarData, dataVal ? HIGH : LOW);
-    delayMicroseconds(1); // > min pulse length 230ns 
+    delayMicroseconds(1); // > min pulse length 230ns
   }
 }
 
@@ -718,7 +728,7 @@ void ledBarUpdate() {
     ledBarLatch();
   }
 }
-       
+
 void ledBarGauge(float level) {
   // set how many leds to be switched on and their brightness
   // as a proportion of level between 0.0 and 1.0
@@ -730,7 +740,7 @@ void ledBarGauge(float level) {
     uint8_t fullLedCnt = min((uint8_t)(level * LEDBAR_COUNT), (uint8_t)(LEDBAR_COUNT - 1));
     for (uint8_t i = 0; i < fullLedCnt; i++) ledLevel[i] = LED_FULL;
     // set brightness for most significant lit led
-    ledBrightness(fullLedCnt, (LEDBAR_COUNT * level) - fullLedCnt); 
+    ledBrightness(fullLedCnt, (LEDBAR_COUNT * level) - fullLedCnt);
     ledBarUpdate();
   }
 }
@@ -755,7 +765,7 @@ void prepPeripherals() {
   setupLamp();
   prepPIR();
   prepTemperature();
-  prepServos();  
+  prepServos();
   prepJoystick();
   prepStepper();
   prepLedBar();

--- a/periphsI2C.cpp
+++ b/periphsI2C.cpp
@@ -7,7 +7,7 @@
 // MPU6050 6 axis accel & gyro
 // MPU9250 9 axis accel & gyro & mag
 // DS3231 RTC
-// LCD 1602 display 2*16 
+// LCD 1602 display 2*16
 //
 // To enable a device, set the appropriate USE_* define in appGlobals.h
 //
@@ -26,10 +26,10 @@
 // if pins not correctly defined for board, spurious results will occur
 int I2Csda = -1;
 int I2Cscl = -1;
-static byte I2CDATA[10]; // store I2C data received or to be sent 
+static byte I2CDATA[10]; // store I2C data received or to be sent
 static int I2Cdevices = -1;
 static bool isShared = false;
-  
+
 // I2C device names, indexed by address
 static bool deviceStatus[128] = {false}; // whether device present
 static const char* clientName[128] = {
@@ -52,10 +52,10 @@ static bool sendTransmission(int clientAddr, bool scanning) {
     /*1: data too long to fit in transmit buffer
       2: received NACK on transmit of address
       3: received NACK on transmit of data
-      4: other error, e.g. switched off 
-      5: i2c busy 
+      4: other error, e.g. switched off
+      5: i2c busy
       8: unknown pcf8591 status */
-      
+
   if (!scanning && result > 0) LOG_WRN("Client %s at 0x%02X with connection error: %d", clientName[clientAddr], clientAddr, result);
   return result == 0;
 }
@@ -87,8 +87,8 @@ static bool getI2Cdata (uint8_t clientAddr, uint8_t controlByte, uint8_t numByte
     Wire.requestFrom (clientAddr, numBytes);
     for (int i=0; i<numBytes; i++) I2CDATA[i] = Wire.read();
     return sendTransmission(clientAddr, false);
-  } 
-  return false; 
+  }
+  return false;
 }
 
 static bool sendI2Cdata(int clientAddr, uint8_t controlByte, uint8_t numBytes) {
@@ -103,9 +103,9 @@ static bool sendI2Cdata(int clientAddr, uint8_t controlByte, uint8_t numBytes) {
 }
 
 bool shareI2C(int sdaShare, int sclShare) {
-  // apply given pins if bus to be shared 
+  // apply given pins if bus to be shared
   /* needs arduino-esp32 core v3.3.0 or higher */
-  if (I2Csda < 0) { 
+  if (I2Csda < 0) {
     // I2C bus shared with another peripheral, eg camera
     I2Csda = sdaShare;
     I2Cscl = sclShare;
@@ -121,7 +121,7 @@ bool prepI2C() {
   if (I2Csda == I2Cscl) {
     LOG_ALT("I2C pins not defined: %d", I2Csda);
     return false;
-  } 
+  }
   // start I2C
   if (!isShared) {
     Wire.begin(I2Csda, I2Cscl); // Join I2C bus as master
@@ -136,7 +136,7 @@ bool prepI2C() {
 
 /***************************************** OLED Display *************************************/
 
-#define SSD1306_BIaddr 0x3d // built in oled 
+#define SSD1306_BIaddr 0x3d // built in oled
 #define SSD1306_Extaddr 0x3c // external oled (also address for OV5640
 #if USE_SSD1306
 #include "SSD1306Wire.h" // https://github.com/ThingPulse/esp8266-oled-ssd1306
@@ -148,8 +148,8 @@ static bool oledOK = false;
 bool flipOled = false; // true if oled pins oriented above display
 
 // OLED SSD1306 display 128*64
-void oledLine(const char* msg, int hpos, int vpos, int msgwidth, int fontsize) { 
-  // display text message on OLED SSD1306 display 
+void oledLine(const char* msg, int hpos, int vpos, int msgwidth, int fontsize) {
+  // display text message on OLED SSD1306 display
   // to avoid flicker, only call periodically
   // args: message string, horizontal pixel start, vertical pixel start, width to clear, font type
   // clear original line
@@ -166,11 +166,11 @@ void oledLine(const char* msg, int hpos, int vpos, int msgwidth, int fontsize) {
   }
 }
 
-static void tellTale() { 
+static void tellTale() {
   static bool ledState = false;
   ledState = !ledState;
   static const char* tellTaleStr[] = {"*", ""}; // shows that oled (& I2C) are running
-  oledLine(tellTaleStr[ledState],124,60,4,10); 
+  oledLine(tellTaleStr[ledState],124,60,4,10);
 }
 
 void oledDisplay() {
@@ -213,7 +213,7 @@ void finalMsg(const char* finalTxt) {
 #define PCF8591addr 0x48 // PCF8591 ADC
 
 byte* getPCF8591() { // analog channels
-/*   
+/*
    YL-40 module
    return the 4 ADC channel 8 bit values, using auto increment control instruction
    PC8591 commands:
@@ -222,13 +222,13 @@ byte* getPCF8591() { // analog channels
    bits 4-5: input programming, separate inputs (00), etc
    bit 6: analog out enable
   */
-  static byte PCF8591[4] = {0}; 
+  static byte PCF8591[4] = {0};
   if (deviceStatus[PCF8591addr]) {
     if (getI2Cdata(PCF8591addr, 0x44, 5)) {
       // need to read 5 bytes, but ignore first as it is previous 0 channel
       // order high -> low channels 3 2 1 0
-      for (int i = 0; i < 4; i++) PCF8591[i] = smoothAnalog(I2CDATA[i + 1]);
-    } 
+      for (int i = 0; i < 4; i++) PCF8591[i] = I2CDATA[i + 1];
+    }
   } else LOG_WRN("PCF8591 ADC not available");
   return PCF8591;
 }
@@ -245,10 +245,10 @@ static bool BMx280ok = false;
 #define STD_PRESSURE 1013.25 // reference pressure in mB/hPa at sea level
 #define DEGREE_SYMBOL "\xC2\xB0"
 
-#if __has_include("../libraries/BMx280MI/src/BMx280I2C.h") 
+#if __has_include("../libraries/BMx280MI/src/BMx280I2C.h")
 
 #include <BMx280I2C.h> // https://github.com/christandlg/BMx280MI
-BMx280I2C bmxDef(BMx280_Def); 
+BMx280I2C bmxDef(BMx280_Def);
 BMx280I2C bmxAlt(BMx280_Alt);
 BMx280I2C* thisBmx;
 
@@ -273,8 +273,8 @@ static float getSeaLevelPressure() {
       if (httpCode == HTTP_CODE_OK) {
         String payload = http.getString();
         if (!getJsonValue(payload.c_str(), "pressure_msl", jsonVal, nullptr, 2)) LOG_WRN("'pressure_msl' field not present");
-      } else LOG_WRN("MSL pressure request failed, error: %s", http.errorToString(httpCode).c_str());    
-      http.end();     
+      } else LOG_WRN("MSL pressure request failed, error: %s", http.errorToString(httpCode).c_str());
+      http.end();
     }
     remoteServerClose(hclient);
   }
@@ -302,11 +302,11 @@ static bool setupBMx() {
       LOG_INF("BMx280 setup complete, local MSL pressure %0.1fhPa @ Lat %0.6f / Lon %0.6f", pressureMSL, latLon[0], latLon[1]);
     }
     if (!BMx280ok) LOG_WRN("BMx280 not available");
-  } 
+  }
   return BMx280ok;
 }
 
-static void updateBMx280() { 
+static void updateBMx280() {
   // get and return pressure, temperature, altitude, humidity
   thisBmx->measure();
   uint32_t bmxWait = millis();
@@ -314,7 +314,7 @@ static void updateBMx280() {
   if (thisBmx->hasValue()) {
     // PSI = pascals * 0.000145
     // ambient temperature (but affected by chip heating)
-    BMx280[0] = thisBmx->getTemperature(); // celsius 
+    BMx280[0] = thisBmx->getTemperature(); // celsius
     BMx280[1] = thisBmx->getPressure() * 0.01;  // pascals to mB/hPa
     BMx280[2] = 44330.0 * (1.0 - pow(BMx280[1] / pressureMSL, 1.0 / 5.255)); // altitude in meters
     if (isBME) BMx280[3] = thisBmx->getHumidity(); // % relative humidity
@@ -371,7 +371,7 @@ static uint8_t MPUaddr;
 #define PWR_MGMT_1 0x6B
 
 bool sleepMPU6050(bool doSleep) {
-  // power down or wake up MPU6050 
+  // power down or wake up MPU6050
   I2CDATA[0] = doSleep ? 0x40 : 0x01;
   // PWR_MGMT_1 register set to sleep
   return sendI2Cdata(MPUaddr, PWR_MGMT_1, 1);
@@ -380,22 +380,22 @@ bool sleepMPU6050(bool doSleep) {
 static bool setupMPU6050() {
   if (!MPU6050ok) {
     // set full range
-    I2CDATA[0] = 0x00; 
+    I2CDATA[0] = 0x00;
     MPU6050ok = sendI2Cdata(MPUaddr, CONFIG, 1);
-    // wakeup the sensor 
+    // wakeup the sensor
     if (MPU6050ok) MPU6050ok = sleepMPU6050(false);
-  } 
+  }
   return MPU6050ok;
 }
 
 static void updateMPU6050data() {
   // get data from MPU6050 and store in array
   if (MPU6050ok) {
-    if (getI2Cdata(MPUaddr, ACCEL_XOUT_H, ACCEL_BYTES+2)) { 
+    if (getI2Cdata(MPUaddr, ACCEL_XOUT_H, ACCEL_BYTES+2)) {
       // read 3 axis accelerometer & temperature
       int16_t raw[4]; // X, Y, Z, Temp
       float axes[4];
-      for (int i=0; i<4; i++) raw[i] = I2CDATA[i*2] << 8 | I2CDATA[(i*2)+1]; 
+      for (int i=0; i<4; i++) raw[i] = I2CDATA[i*2] << 8 | I2CDATA[(i*2)+1];
       // each axis G force value, straight down is 1.0 if stationary
       for (int i=0; i<3; i++) axes[i] = (float)raw[i] / SENS_2G;
       // determine gravity from all 3 axes (no linear velocity)
@@ -404,14 +404,14 @@ static void updateMPU6050data() {
       // pitch in degrees - X axis
       float ratio = axes[0] / gXYZ;
       mpuData[0] = (float)((ratio < 0.5) ? 90-fabsf(asin(ratio)*RAD_TO_DEG) : fabsf(acos(ratio)*RAD_TO_DEG));
-      // roll in degrees - Y axis 
+      // roll in degrees - Y axis
       ratio = axes[1] / gXYZ;
       mpuData[1] = (float)((ratio < 0.5) ? 90-fabsf(asin(ratio)*RAD_TO_DEG) : fabsf(acos(ratio)*RAD_TO_DEG));
       // yaw in degrees - Z axis (inaccurate as gravity is constant)
       ratio = axes[2] / gXYZ;
       mpuData[2] = (float)((ratio < 0.5) ? 90-fabsf(asin(ratio)*RAD_TO_DEG) : fabsf(acos(ratio)*RAD_TO_DEG));
       // temperature in degrees celsius
-      mpuData[3] = ((float)raw[3] / 340.0) + 36.53; 
+      mpuData[3] = ((float)raw[3] / 340.0) + 36.53;
     }
   }
 }
@@ -423,8 +423,8 @@ MPU9250 on GY-91
 VIN: Voltage Supply Pin
 3V3: 3.3v Regulator output
 GND: 0V Power Supply
-SCL: I2C Clock 
-SDA: I2C Data 
+SCL: I2C Clock
+SDA: I2C Data
 SDO/SAO: I2C Address selection MPU9250
 NCS: n/a
 CSB: I2C Address selection BMP280
@@ -468,7 +468,7 @@ static float getMagneticDeclination() {
             if (strstr(jsonVal, "west")) sign = -1.0f;
           }
         } else LOG_WRN("'declination' field not present");
-      } else LOG_WRN("Magnetic declination request failed, error: %s", http.errorToString(httpCode).c_str());    
+      } else LOG_WRN("Magnetic declination request failed, error: %s", http.errorToString(httpCode).c_str());
       http.end();
     }
     remoteServerClose(hclient);
@@ -511,7 +511,7 @@ static bool setupMPU9250() {
   return MPU9250ok;
 }
 
-#else 
+#else
 
 static bool setupMPU9250() {
   LOG_WRN("MPU9250 library not installed");
@@ -607,13 +607,13 @@ static bool setupRTC() {
         LOG_WRN("RTC is older than compile time, updating DateTime");
         Rtc.SetDateTime(compiled);
       }
-      
+
       Rtc.Enable32kHzPin(false);
       Rtc.SetSquareWavePin(DS3231SquareWavePin_ModeAlarmBoth); // set to be alarm output
       Rtc.LatchAlarmsTriggeredFlags();  // throw away any old alarm state
-      // setup alarm interrupt 
+      // setup alarm interrupt
       attachInterrupt(digitalPinToInterrupt(SQWpin), RTCalarmISR, FALLING);
-      
+
       DS3231ok = true;
     } else DS3231ok = false;
   }
@@ -675,10 +675,10 @@ int RTCalarmed() {
   // check if RTC alarm occurred and return alarm number
   int wasAlarmed = 0;
   if (DS3231ok) {
-    if (RTCalarmFlag) { 
+    if (RTCalarmFlag) {
       RTCalarmFlag = false; // reset the flag
       DS3231AlarmFlag flag = Rtc.LatchAlarmsTriggeredFlags(); // which alarms triggered and reset for next
-      if (flag & DS3231AlarmFlag_Alarm1) wasAlarmed = 1; 
+      if (flag & DS3231AlarmFlag_Alarm1) wasAlarmed = 1;
       if (flag & DS3231AlarmFlag_Alarm2) wasAlarmed = 2;
     }
   }
@@ -707,7 +707,7 @@ void RTCdatetime(char* datestring, int datestringLen) {
 
 
 /**************************** LCD1602 ******************************/
-// I2C LCD display: 2 lines, 16 cols 
+// I2C LCD display: 2 lines, 16 cols
 // Derived from https://github.com/arduino-libraries/LiquidCrystal
 
 #define LCD1602 0x27 // 16 chars by 2 lines LCD
@@ -770,7 +770,7 @@ static uint8_t backlightval;
 static void lcdWrite(uint8_t data) {
   if (LCD1602ok) {
     I2CDATA[0] = data | backlightval;
-    sendI2Cdata(LCD1602, 0, 1); 
+    sendI2Cdata(LCD1602, 0, 1);
   }
 }
 
@@ -786,7 +786,7 @@ static void lcdSend(uint8_t value, uint8_t mode = 0) {
   // write either command (mode = 0) or data, as two 4 bit values
   if (LCD1602ok) {
     writeNibble((value & 0xf0) | mode);
-    writeNibble(((value << 4 ) & 0xf0) | mode); 
+    writeNibble(((value << 4 ) & 0xf0) | mode);
   }
 }
 
@@ -799,13 +799,13 @@ void lcdBacklight(bool lightOn) {
 void lcdClear() {
   // clear display, set cursor position to zero
   lcdSend(LCD_CLEARDISPLAY);
-  delayMicroseconds(2000);  
+  delayMicroseconds(2000);
 }
 
 void lcdHome() {
   // set cursor position to zero
-  lcdSend(LCD_RETURNHOME);  
-  delayMicroseconds(2000); 
+  lcdSend(LCD_RETURNHOME);
+  delayMicroseconds(2000);
 }
 
 void lcdDisplay(bool setDisplay) {
@@ -815,14 +815,14 @@ void lcdDisplay(bool setDisplay) {
   lcdSend(LCD_DISPLAYCONTROL | displaycontrol);
 }
 
-static bool setupLCD1602() {  
+static bool setupLCD1602() {
   if (!LCD1602ok) {
     if (deviceStatus[LCD1602]) {
       LCD1602ok = true;
-      delay(50); 
+      delay(50);
       lcdBacklight(false);
       delay(1000);
-  
+
       // can only use 4 bit mode with PCF8574 as not enough pins for HD44780 8 bit.
       // use magic sequence to set it
       writeNibble(0x03 << 4);
@@ -832,20 +832,20 @@ static bool setupLCD1602() {
       writeNibble(0x03 << 4);
       delayMicroseconds(150);
       writeNibble(0x02 << 4);
-    
+
        // set initial display format
-      lcdSend(LCD_FUNCTIONSET | LCD_4BITMODE | LCD_2LINE | LCD_5x8DOTS);  
-      
+      lcdSend(LCD_FUNCTIONSET | LCD_4BITMODE | LCD_2LINE | LCD_5x8DOTS);
+
       // turn on display and clear content
-      displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF; 
+      displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
       lcdDisplay(true);
       lcdClear();
-      
+
       // set the entry mode and set cursor position to top left
       displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
-      lcdSend(LCD_ENTRYMODESET | displaymode); 
+      lcdSend(LCD_ENTRYMODESET | displaymode);
       lcdHome();
-      lcdBacklight(true); 
+      lcdBacklight(true);
     } else LCD1602ok = false;
     if (!LCD1602ok) LOG_WRN("LCD1602 display not available");
   }
@@ -860,7 +860,7 @@ void lcdPrint(const char* str) {
 
 void lcdSetCursorPos(uint8_t row, uint8_t col) {
   // set row and col of cursor position
-	int row_offsets[] = {0x00, 0x40, 0x14, 0x54}; 
+	int row_offsets[] = {0x00, 0x40, 0x14, 0x54};
   if (row >= NUM_ROWS) row = NUM_ROWS - 1;
   if (col >= NUM_COLS) col = NUM_COLS - 1;
 	lcdSend(LCD_SETDDRAMADDR | (col + row_offsets[row]));
@@ -887,7 +887,7 @@ void lcdScrollText(bool scrollLeft) {
 }
 
 void lcdTextDirection(bool scrollLeft) {
-  // write text forward or backward from cursor 
+  // write text forward or backward from cursor
   if (scrollLeft) displaymode &= ~LCD_ENTRYLEFT;
   else displaymode |= LCD_ENTRYLEFT;
 	lcdSend(LCD_ENTRYMODESET | displaymode);
@@ -895,8 +895,8 @@ void lcdTextDirection(bool scrollLeft) {
 
 void lcdAutoScroll(bool autoScroll) {
   // As each character entered at cursor, scroll previous text left
-	if (autoScroll) displaymode |= LCD_ENTRYSHIFTINCREMENT; 
-  else displaymode &= ~LCD_ENTRYSHIFTINCREMENT; 
+	if (autoScroll) displaymode |= LCD_ENTRYSHIFTINCREMENT;
+  else displaymode &= ~LCD_ENTRYSHIFTINCREMENT;
 	lcdSend(LCD_ENTRYMODESET | displaymode);
 }
 
@@ -904,14 +904,14 @@ void lcdLoadCustom(uint8_t charLoc, uint8_t charmap[]) {
   // Load custom character
   if (charLoc > 7) LOG_WRN("custom char number %u out of range", charLoc);
   else {
-  	charLoc &= 0x7; // CGRAM location to load 0 - 7
-  	lcdSend(LCD_SETCGRAMADDR | (charLoc << 3));
-  	for (int i=0; i<8; i++)	lcdSend(charmap[i], Rs);
+	charLoc &= 0x7; // CGRAM location to load 0 - 7
+	lcdSend(LCD_SETCGRAMADDR | (charLoc << 3));
+	for (int i=0; i<8; i++)	lcdSend(charmap[i], Rs);
   }
 }
 
 void lcdWriteCustom(uint8_t charLoc) {
-  // write one of 8 custom chars 
+  // write one of 8 custom chars
   if (charLoc > 7) LOG_WRN("custom char number %u out of range", charLoc);
   else lcdSend(charLoc, Rs);
 }
@@ -975,7 +975,7 @@ static void startPollTask() {
 #if USE_TELEM
   pollInterval = srtInterval;
 #endif
-  if (sensorPollHandle == NULL) xTaskCreateWithCaps(sensorPollTask, "sensorPollTask", SENSOR_STACK_SIZE, NULL, SENSOR_PRI, &sensorPollHandle, STACK_MEM); 
+  if (sensorPollHandle == NULL) xTaskCreateWithCaps(sensorPollTask, "sensorPollTask", SENSOR_STACK_SIZE, NULL, SENSOR_PRI, &sensorPollHandle, STACK_MEM);
 }
 
 #endif  // IS_POLLABLE
@@ -995,7 +995,7 @@ bool checkI2Cdevice(const char* devName) {
 }
 
 static bool prepI2Cdevices() {
-  // setup available I2C devices 
+  // setup available I2C devices
   bool res = false;
   if (I2Cdevices == 0) LOG_WRN("No I2C devices connected");
   else {

--- a/utils.cpp
+++ b/utils.cpp
@@ -30,7 +30,7 @@ uint32_t deepSleepTimer = 0;
 /************************** Network (WiFi/Ethernet) **************************/
 
 #include <esp_task_wdt.h>
- 
+
 /** Do not hard code anything below here unless you know what you are doing **/
 /** Use the web interface to configure wifi settings **/
 
@@ -61,7 +61,7 @@ int ethMiso = -1; // W5500 SPI data pin
 int ethMosi = -1; // W5500 SPI data pin
 
 // basic HTTP Authentication access to web page
-char Auth_Name[MAX_HOST_LEN] = ""; 
+char Auth_Name[MAX_HOST_LEN] = "";
 char Auth_Pass[MAX_PWD_LEN] = "";
 
 int responseTimeoutSecs = 10; // time to wait for FTP or SMTP response
@@ -77,11 +77,11 @@ static bool getLocalNTP();
 int netMode = 0; // 0=WiFi only, 1=Ethernet only, 2=Ethernet+AP
 
 // LAN8720
-#define ETH_PHY_ADDR  0 
+#define ETH_PHY_ADDR  0
 #define ETH_CLK_MODE  ETH_CLOCK_GPIO0_IN // external clock from crystal oscillator
 
-static void setupMdnsHost() {  
-  // set up MDNS service 
+static void setupMdnsHost() {
+  // set up MDNS service
   char mdnsName[MAX_IP_LEN]; // max mdns host name length
   snprintf(mdnsName, MAX_IP_LEN, "%.*s", MAX_IP_LEN - 1, hostName);
   MDNS.end();
@@ -89,7 +89,7 @@ static void setupMdnsHost() {
     // Add service to MDNS
     useHttps ? MDNS.addService("https", "tcp", HTTPS_PORT) : MDNS.addService("http", "tcp", HTTP_PORT);
     MDNS.addService("ws", "udp", 83);
-    MDNS.addService("ftp", "tcp", 21);    
+    MDNS.addService("ftp", "tcp", 21);
     LOG_INF("mDNS service: http%s://%s.local", useHttps ? "s" : "", mdnsName);
   } else LOG_WRN("mDNS host: %s Failed", mdnsName);
   debugMemory("setupMdnsHost");
@@ -104,7 +104,7 @@ static const char* wifiStatusStr(wl_status_t wlStat) {
     case WL_CONNECTED: return "WL_CONNECTED";
     case WL_CONNECT_FAILED: return "WL_CONNECT_FAILED";
     case WL_CONNECTION_LOST: return "WL_CONNECTION_LOST";
-    case WL_DISCONNECTED: return "unable to connect";  
+    case WL_DISCONNECTED: return "unable to connect";
     case WL_STOPPED: return "wifi stopped";
     default: return "Invalid WiFi.status";
   }
@@ -159,7 +159,7 @@ static void onNetEvent(arduino_event_id_t event, arduino_event_info_t info) {
     case ARDUINO_EVENT_ETH_CONNECTED: LOG_INF("Ethernet connected, MAC: %s", ETH.macAddress().c_str()); break;
     case ARDUINO_EVENT_ETH_STOP: LOG_INF("Ethernet Stopped"); break;
     case ARDUINO_EVENT_ETH_GOT_IP: {
-      LOG_INF("Ethernet IP, use '%s://%s' to connect", useHttps ? "https" : "http", formatIPstr()); 
+      LOG_INF("Ethernet IP, use '%s://%s' to connect", useHttps ? "https" : "http", formatIPstr());
       if (netMode == 2) WiFi.AP.enableNAPT(true);
       break;
     }
@@ -182,14 +182,14 @@ static void setWifiAP() {
     WiFi.AP.begin();
     // Set access point with static ip if provided
     if (strlen(AP_ip) > 1) {
-      LOG_INF("Set AP static IP :%s, %s, %s", AP_ip, AP_gw, AP_sn);  
+      LOG_INF("Set AP static IP :%s, %s, %s", AP_ip, AP_gw, AP_sn);
       IPAddress _ip, _gw, _sn, _ns1, _ns2;
       _ip.fromString(AP_ip);
       _gw.fromString(AP_gw);
       _sn.fromString(AP_sn);
       // set static ip
       WiFi.AP.config(_ip, _gw, _sn);
-    } 
+    }
     WiFi.AP.create(AP_SSID, AP_Pass);
     debugMemory("setWifiAP");
   }
@@ -209,9 +209,9 @@ static void setWifiSTA() {
       // set static ip
       WiFi.STA.config(_ip, _gw, _sn, _ns1); // need DNS for SNTP
       LOG_INF("Wifi Station set static IP");
-    } 
+    }
   } else LOG_INF("Wifi Station IP from DHCP");
-  WiFi.STA.enableIPv6(USE_IP6); 
+  WiFi.STA.enableIPv6(USE_IP6);
   WiFi.STA.begin();
   WiFi.STA.connect(ST_SSID, ST_Pass);
   debugMemory("setWifiSTA");
@@ -257,7 +257,7 @@ static bool startEth(bool firstcall) {
                    ethSclk,
                    ethMiso,
                    ethMosi,
-                   ETH_PHY_SPI_FREQ_MHZ)) { 
+                   ETH_PHY_SPI_FREQ_MHZ)) {
       LOG_WRN("Ethernet W5500 init failed");
       return false;
     }
@@ -271,10 +271,10 @@ static bool startEth(bool firstcall) {
     // RMII uses predefined pins 19, 21, 22, 25, 26, 27
     if (!ETH.begin(ETH_PHY_LAN8720,
                    ETH_PHY_ADDR,
-                   ethCS,  // LAN8720 MDC 
+                   ethCS,  // LAN8720 MDC
                    ethInt, // LAN8720 MDIO
                    ethRst, // LAN8720 POWER
-                   ETH_CLK_MODE)) { 
+                   ETH_CLK_MODE)) {
       LOG_WRN("Ethernet LAN8720 init failed");
       return false;
     }
@@ -321,7 +321,7 @@ static bool startWifi(bool firstcall = true) {
     WiFi.STA.setHostname(hostName);
     delay(100);
   }
-  
+
   wl_status_t wlStat = WL_NO_SSID_AVAIL;
   if (netMode == 0) {
     // connect to Wifi station
@@ -343,8 +343,8 @@ static bool startWifi(bool firstcall = true) {
     }
     if (wlStat != WL_CONNECTED) LOG_WRN("SSID %s not connected %s", ST_SSID, wifiStatusStr(wlStat));
   }
-  
-  if (wlStat == WL_NO_SSID_AVAIL || allowAP) setWifiAP(); // AP allowed if no Station SSID eg on first time use 
+
+  if (wlStat == WL_NO_SSID_AVAIL || allowAP) setWifiAP(); // AP allowed if no Station SSID eg on first time use
 #if CONFIG_IDF_TARGET_ESP32S3
   if (netMode == 0) setupMdnsHost(); // not on ESP32 as uses 6k of heap
 #endif
@@ -382,7 +382,7 @@ bool startNetwork(bool firstcall) {
   }
   // connect wifi STA, or AP if router details not available
   if (!res) startWifi(firstcall);
-  res = startWebServer(); 
+  res = startWebServer();
 #ifdef DEV_ONLY
   devCheck();
 #endif
@@ -398,7 +398,7 @@ bool netIsConnected() { return (netMode > 0) ? (ETH.linkUp() && ETH.localIP()) :
 const char* formatIPstr(bool getAP) {
   static char localIP[16] = "";
   IPAddress ipLocal = getAP ? WiFi.AP.localIP() : netLocalIP();
-  sprintf(localIP, "%u.%u.%u.%u", ipLocal[0], ipLocal[1], ipLocal[2], ipLocal[3]); 
+  sprintf(localIP, "%u.%u.%u.%u", ipLocal[0], ipLocal[1], ipLocal[2], ipLocal[3]);
   return localIP;
 }
 
@@ -409,7 +409,7 @@ void resetWatchDog(int wdIndex, uint32_t wdTimeout) {
   if (watchDogStarted[wdIndex]) esp_task_wdt_reset();
   else {
     // setup watchdog on first call
-    esp_task_wdt_deinit(); 
+    esp_task_wdt_deinit();
     esp_task_wdt_config_t twdt_config = {
       .timeout_ms = wdTimeout,
       .idle_core_mask = (1 << portNUM_PROCESSORS) - 1,
@@ -488,20 +488,20 @@ static void pingTimeout(esp_ping_handle_t hdl, void *args) {
 static void startPing() {
   IPAddress ipAddr = netGatewayIP();
   if (!ipAddr) return; // don't start ping until gateway is known
-  ip_addr_t pingDest; 
+  ip_addr_t pingDest;
   IP_ADDR4(&pingDest, ipAddr[0], ipAddr[1], ipAddr[2], ipAddr[3]);
   esp_ping_config_t pingConfig = ESP_PING_DEFAULT_CONFIG();
-  pingConfig.target_addr = pingDest;  
+  pingConfig.target_addr = pingDest;
   pingConfig.count = ESP_PING_COUNT_INFINITE;
   pingConfig.interval_ms = wifiTimeoutSecs * 1000;
   pingConfig.timeout_ms = 5000;
   pingConfig.task_stack_size = PING_STACK_SIZE;
   pingConfig.task_prio = 1;
-  // set ping task callback functions 
+  // set ping task callback functions
   esp_ping_callbacks_t cbs;
   cbs.on_ping_success = pingSuccess;
   cbs.on_ping_timeout = pingTimeout;
-  cbs.on_ping_end = NULL; 
+  cbs.on_ping_end = NULL;
   cbs.cb_args = NULL;
   esp_ping_new_session(&pingConfig, &cbs, &pingHandle);
   esp_ping_start(pingHandle);
@@ -524,7 +524,7 @@ bool doGetExtIP = true;
 
 void getExtIP() {
   // Get external IP address
-  if (doGetExtIP) { 
+  if (doGetExtIP) {
     NetworkClient hclient;
     if (remoteServerConnect(hclient, EXT_IP_HOST, HTTP_PORT, GETEXTIP)) {
       HTTPClient http;
@@ -543,13 +543,13 @@ void getExtIP() {
               externalAlert("External IP changed", extIP);
             } else LOG_INF("External IP: %s", extIP);
           } else LOG_WRN("'ip' field not present");
-          
+
           if (getJsonValue(payload.c_str(), "latitude", jsonVal)) latLon[0] = atof(jsonVal);
           else LOG_WRN("'latitude' field not present");
           if (getJsonValue(payload.c_str(), "longitude", jsonVal)) latLon[1] = atof(jsonVal);
           else LOG_WRN("'longitude' field not present");
-        } else LOG_WRN("External IP request failed, error: %s", http.errorToString(httpCode).c_str());    
-        
+        } else LOG_WRN("External IP request failed, error: %s", http.errorToString(httpCode).c_str());
+
         if (httpCode != HTTP_CODE_OK) doGetExtIP = false;
         http.end();
       }
@@ -577,7 +577,7 @@ static bool checkFailureThreshold(const char* host, uint8_t idx) {
       failCounts[idx] = MAX_FAIL + 1;
     }
     return false;
-  } 
+  }
   return true;
 }
 
@@ -589,7 +589,7 @@ bool remoteServerConnect(Client& client, const char* host, uint16_t port, uint8_
     while (!client.connected()) {
       if (client.connect(host, port)) break;
       if (millis() - start > (uint32_t)responseTimeoutSecs * 1000) break;
-      delay(500); 
+      delay(500);
     }
 
     // Final status & error reporting
@@ -813,7 +813,7 @@ void removeChar(char* s, char c) {
   int writer = 0, reader = 0;
   while (s[reader]) {
     if (s[reader] != c) s[writer++] = s[reader];
-    reader++;       
+    reader++;
   }
   s[writer] = 0;
 }
@@ -865,23 +865,13 @@ char* toCase(char *s, bool toLower) {
 
 /********************** analog functions ************************/
 
-uint16_t smoothAnalog(int analogPin, int samples) {
-  // get averaged analog pin value 
-  uint32_t level = 0; 
-  if (analogPin > 0) {
-    for (int j = 0; j < samples; j++) level += analogRead(analogPin); 
-    level /= samples;
-  }
-  return level;
-}
-
 void setupADC() {
   analogSetAttenuation(ADC_ATTEN);
   analogReadResolution(ADC_BITS);
 }
 
 float smoothSensor(float latestVal, float smoothedVal, float alpha) {
-  // simple Exponential Moving Average filter 
+  // simple Exponential Moving Average filter
   // where alpha between 0.0 (max smooth) and 1.0 (no smooth)
   return (latestVal * alpha) + smoothedVal * (1.0 - alpha);
 }
@@ -912,7 +902,7 @@ float readInternalTemp() {
   // convert on chip raw temperature in F to Celsius degrees
   intTemp = (temprature_sens_read() - 32) / 1.8;  // value of 55 means not present
 #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
-    temperature_sensor_get_celsius(temp_sensor, &intTemp); 
+    temperature_sensor_get_celsius(temp_sensor, &intTemp);
 #endif
   return intTemp;
 }
@@ -924,15 +914,15 @@ float readInternalTemp() {
 
 const uint8_t* encode64chunk(const uint8_t* inp, int rem) {
   // receive 3 byte input buffer and return 4 byte base64 buffer
-  rem = 3 - rem; // last chunk may be less than 3 bytes 
+  rem = 3 - rem; // last chunk may be less than 3 bytes
   uint32_t buff = 0; // hold 3 bytes as shifted 24 bits
   static uint8_t b64[4];
   // shift input into buffer
-  for (int i = 0; i < 3 - rem; i++) buff |= inp[i] << (8*(2-i)); 
+  for (int i = 0; i < 3 - rem; i++) buff |= inp[i] << (8*(2-i));
   // shift 6 bit output from buffer and encode
-  for (int i = 0; i < 4 - rem; i++) b64[i] = BASE64[buff >> (6*(3-i)) & 0x3F]; 
+  for (int i = 0; i < 4 - rem; i++) b64[i] = BASE64[buff >> (6*(3-i)) & 0x3F];
   // filler for last chunk if less than 3 bytes
-  for (int i = 0; i < rem; i++) b64[3-i] = '='; 
+  for (int i = 0; i < rem; i++) b64[3-i] = '=';
   return b64;
 }
 
@@ -972,7 +962,7 @@ void doRestart(const char* restartStr) {
 #endif
 #if INCLUDE_MQTT
   if (mqtt_active) stopMqttClient();
-#endif  
+#endif
   resetCrashLoop();
   flush_log(true);
   delay(2000);
@@ -997,7 +987,7 @@ void goToSleep(bool deepSleep) {
   // if light sleep, restarts by continuing this function
   LOG_INF("Going into %s sleep", deepSleep ? "deep" : "light");
   delay(100);
-  if (deepSleep) { 
+  if (deepSleep) {
     if (wakePin >= 0) {
       // wakeup on pin low (0) or high (1)
       // needs to be RTC pin and support input pullup/down
@@ -1015,7 +1005,7 @@ void goToSleep(bool deepSleep) {
     // light sleep
     esp_wifi_stop();
     // wakeup on selected pin
-    if (wakePin >= 0) gpio_wakeup_enable((gpio_num_t)wakePin, wakeLevel == 0 ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL); 
+    if (wakePin >= 0) gpio_wakeup_enable((gpio_num_t)wakePin, wakeLevel == 0 ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
     esp_light_sleep_start();
   }
   // light sleep restarts here
@@ -1038,11 +1028,11 @@ bool utilsStartup() {
   logSetup();
 #ifdef NEED_PSRAM
   if (psramFound()) {
-    if (ESP.getPsramSize() < MIN_PSRAM * ONEMEG) 
+    if (ESP.getPsramSize() < MIN_PSRAM * ONEMEG)
       snprintf(startupFailure, SF_LEN, STARTUP_FAIL "App needs at least %dMB PSRAM", MIN_PSRAM);
   } else snprintf(startupFailure, SF_LEN, STARTUP_FAIL "Need PSRAM to be enabled");
 #endif
-  
+
   prepInternalTemp();
   if (jsonBuff == NULL) jsonBuff = psramFound() ? (char*)ps_malloc(JSON_BUFF_LEN) : (char*)malloc(JSON_BUFF_LEN);
   LOG_INF("Compiled with arduino-esp32 v%s", ESP_ARDUINO_VERSION_STR);


### PR DESCRIPTION
🎯 **What:** Removed the `smoothAnalog` function from `utils.cpp` and `globals.h` and moved it into `peripherals.cpp` where it is actually used. Also fixed a bug in `periphsI2C.cpp` where the raw external I2C analog value was erroneously being passed to `smoothAnalog` as if it were a pin number.
💡 **Why:** `smoothAnalog` was meant to be a helper specific to reading on-board ADC pins, which is only done inside the `INCLUDE_PERIPH` feature code in `peripherals.cpp`. Having it sit globally in `utils.cpp` created "dead code" for anyone compiling with the default `INCLUDE_PERIPH=false`, while removing it blindly would break the build when `INCLUDE_PERIPH` is turned on. Making it a static helper localized to `peripherals.cpp` improves codebase cleanliness while safely retaining functionality.
✅ **Verification:** Verified by compiling the default configurations, and by reviewing the local changes to `peripherals.cpp` and `periphsI2C.cpp`. Also ran C++ mock tests.
✨ **Result:** A cleaner global utility layer, accurate elimination of dead code without breaking peripheral features, and a bug fix in I2C peripheral handling.

---
*PR created automatically by Jules for task [514663044901898347](https://jules.google.com/task/514663044901898347) started by @ManupaKDU*