### PR TITLE
🎨 Palette: Add helpful empty state to Camera Hub

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -882,6 +882,16 @@
         margin-left: var(--buttonDbl);
       }
 
+      #imageContainer:empty::after {
+        content: "No cameras added. Enter an IP address above to add a camera.";
+        display: block;
+        grid-column: 1 / -1;
+        text-align: center;
+        color: var(--itemInactive);
+        font-size: var(--headingSize);
+        padding: calc(var(--buttonSize) * 2);
+      }
+
       .hubImg {
         max-width: 100%;
         height: auto;


### PR DESCRIPTION
💡 What: Added a CSS empty state with a helpful message to the Camera Hub (`#imageContainer:empty::after`).
🎯 Why: To guide users on what to do when no cameras are configured, improving onboarding experience.
📸 Before/After: Replaced blank space with a clear call-to-action message.
♿ Accessibility: Improves screen reader comprehension of the empty container state by providing readable text content when it is empty.

---
*PR created automatically by Jules for task [10247528986341906028](https://jules.google.com/task/10247528986341906028) started by @ManupaKDU*