### PR TITLE
⚡ Replace blocking delay in Telegram client with conditional vTaskDelay

### DIFF
--- a/telegram.cpp
+++ b/telegram.cpp
@@ -115,8 +115,11 @@ static bool getTgramResponse() {
       // retrieve response content
       size_t availLen = tclient.available();
       // ⚡ Bolt optimization: Use block read() instead of readBytes() to bypass per-byte timedRead() overhead
-      if (availLen) readLen += tclient.read((uint8_t*)tgramBuff + readLen, availLen);
-      delay(50);
+      if (availLen) {
+        readLen += tclient.read((uint8_t*)tgramBuff + readLen, availLen);
+      } else {
+        vTaskDelay(pdMS_TO_TICKS(10));
+      }
     }
     if (contentLen - readLen > 0) LOG_WRN("Timed out waiting for telegram response");
     else {


### PR DESCRIPTION
💡 **What:** Modified `telegram.cpp` to conditionally yield via `vTaskDelay` instead of unconditionally using `delay(50)`.
🎯 **Why:** The original loop blocked the task with a 50ms delay for every chunk read, degrading performance. The new code only yields if no data is available, significantly speeding up data consumption while still cooperating with the RTOS.
📊 **Measured Improvement:** The change prevents a forced 50ms block per chunk when data is actually ready to be read, accelerating network response ingestion. The specific latency decrease is unmeasured since the code interacts directly with the live Telegram API, but eliminating O(N) 50ms pauses theoretically brings down the fetch time from (50ms * number of chunks) to near-zero network latency.

---
*PR created automatically by Jules for task [17278939709238602944](https://jules.google.com/task/17278939709238602944) started by @ManupaKDU*