### PR TITLE
🔒 Fix Buffer Overflow in Directory Path strcpy

### DIFF
--- a/utilsFS.cpp
+++ b/utilsFS.cpp
@@ -162,11 +162,17 @@ static void getOldestDir(char* oldestDir) {
   // get oldest folder by its date name
   File root = STORAGE.open("/");
   File file = root.openNextFile();
-  if (file) strcpy(oldestDir, file.path()); // initialise oldestDir
+  if (file) {
+    strncpy(oldestDir, file.path(), FILE_NAME_LEN - 1); // initialise oldestDir
+    oldestDir[FILE_NAME_LEN - 1] = '\0';
+  }
   while (file) {
     if (file.isDirectory() && strstr(file.name(), "System") == NULL // ignore Sys Vol Info
         && strstr(DATA_DIR, file.name()) == NULL) { // ignore data folder
-      if (strcmp(oldestDir, file.path()) > 0) strcpy(oldestDir, file.path()); 
+      if (strcmp(oldestDir, file.path()) > 0) {
+        strncpy(oldestDir, file.path(), FILE_NAME_LEN - 1);
+        oldestDir[FILE_NAME_LEN - 1] = '\0';
+      }
     }
     file = root.openNextFile();
   }


### PR DESCRIPTION
🎯 **What:** Replace `strcpy` with `strncpy` and explicit null-termination in `getOldestDir` in `utilsFS.cpp` to prevent buffer overflow vulnerabilities when directory paths exceed `FILE_NAME_LEN`.
⚠️ **Risk:** A buffer overflow could overwrite adjacent memory, leading to crashes or arbitrary code execution, especially when processing untrusted filesystem inputs (e.g., from an SD card).
🛡️ **Solution:** Used `strncpy` clamped to `FILE_NAME_LEN - 1` with explicit null-termination to safely initialize and update the `oldestDir` buffer.

---
*PR created automatically by Jules for task [16984573986704592088](https://jules.google.com/task/16984573986704592088) started by @ManupaKDU*