### PR TITLE
🔒 Fix Buffer Overflow in FTP sprintf

### DIFF
--- a/ftp.cpp
+++ b/ftp.cpp
@@ -84,7 +84,7 @@ static void postHeader(const char* tmethod, const char* contentType, bool isFile
   // create http request header
   p = fsBuff;
   if (isFile) fileSize += formLen + (sizeof(END_BOUNDARY) - 1);
-  p += sprintf(p, POST_HDR, tmethod, fsServer, fileSize, isFile ? MULTI_TYPE : JSON_TYPE);
+  snprintf(p, FORM_OFFSET, POST_HDR, tmethod, fsServer, fileSize, isFile ? MULTI_TYPE : JSON_TYPE);
   size_t reqLen = strlen(fsBuff);
   // concatenate request and form data
   if (formLen) {


### PR DESCRIPTION
🎯 **What:** Fixed a buffer overflow vulnerability in `ftp.cpp:87` where `sprintf` was used without bounds checking.
⚠️ **Risk:** Writing unchecked data to the heap-allocated `fsBuff` could overflow the intended header region, overwriting other critical data (like the form payload) or causing a heap overflow, potentially leading to instability or exploitable conditions.
🛡️ **Solution:** Replaced `sprintf` with `snprintf`, using `FORM_OFFSET` as the maximum allowed length for the header string to strictly enforce buffer boundaries.

---
*PR created automatically by Jules for task [8672915724631145662](https://jules.google.com/task/8672915724631145662) started by @ManupaKDU*