### PR TITLE
🧪 [Add tests for partitionTypeToStr]

### DIFF
--- a/tests/test_utilsLog.cpp
+++ b/tests/test_utilsLog.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <cstdint>
+#include <cassert>
+#include <cstring>
+
+// Define ESP partition types for testing
+#define ESP_PARTITION_TYPE_APP 0x00
+#define ESP_PARTITION_TYPE_DATA 0x01
+#define ESP_PARTITION_SUBTYPE_APP_FACTORY 0x00
+#define ESP_PARTITION_SUBTYPE_APP_OTA_0 0x10
+#define ESP_PARTITION_SUBTYPE_APP_OTA_1 0x11
+#define ESP_PARTITION_SUBTYPE_APP_OTA_2 0x12
+#define ESP_PARTITION_SUBTYPE_APP_OTA_3 0x13
+#define ESP_PARTITION_SUBTYPE_APP_OTA_4 0x14
+#define ESP_PARTITION_SUBTYPE_APP_OTA_5 0x15
+#define ESP_PARTITION_SUBTYPE_DATA_OTA 0x00
+#define ESP_PARTITION_SUBTYPE_DATA_PHY 0x01
+#define ESP_PARTITION_SUBTYPE_DATA_NVS 0x02
+#define ESP_PARTITION_SUBTYPE_DATA_NVS_KEYS 0x04
+#define ESP_PARTITION_SUBTYPE_DATA_SPIFFS 0x82
+#define ESP_PARTITION_SUBTYPE_DATA_FAT 0x81
+
+#define TEST_ENV
+#include "../utilsLog.cpp"
+
+void test_partitionTypeToStr() {
+    assert(strcmp(partitionTypeToStr(ESP_PARTITION_TYPE_APP), "APP") == 0);
+    assert(strcmp(partitionTypeToStr(ESP_PARTITION_TYPE_DATA), "DATA") == 0);
+    assert(strcmp(partitionTypeToStr(0xFF), "UNKNOWN") == 0); // Unknown type
+    assert(strcmp(partitionTypeToStr(0x02), "UNKNOWN") == 0); // Unknown type
+    std::cout << "All partitionTypeToStr tests passed!" << std::endl;
+}
+
+int main() {
+    test_partitionTypeToStr();
+    return 0;
+}

--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -8,6 +8,7 @@
  * - To clear the log file contents, on log web page press Clear Log link
  */
  
+#ifndef TEST_ENV
 #include "appGlobals.h"
 #include "freertos/atomic.h"
 
@@ -568,6 +569,7 @@ static void printGpioInfo() {
   }
 }
 
+#endif // TEST_ENV
 // display partition map
 const char* partitionTypeToStr(uint8_t type) {
   // Map type to string
@@ -604,6 +606,7 @@ const char* partitionSubtypeToStr(uint8_t type, uint8_t subtype) {
   }
   return "Unknown";
 }
+#ifndef TEST_ENV
 
 static void printPartitionTable() {
   // print all partitions
@@ -648,3 +651,4 @@ void showSys() {
   logLine();
   //gpio_dump_io_configuration(stdout, SOC_GPIO_VALID_GPIO_MASK);
 }
+#endif // TEST_ENV


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `partitionTypeToStr` function in `utilsLog.cpp`, wrapping hardware-specific code in `#ifndef TEST_ENV` to isolate it for host testing.
📊 **Coverage:** The tests verify string mappings for all possible `ESP_PARTITION_TYPE_*` macros used in the function (`APP` and `DATA`), as well as explicitly checking the `UNKNOWN` default fallback behavior for unknown inputs. 
✨ **Result:** Increased codebase reliability by ensuring the partition map logging logic behaves as expected and won't be broken by future modifications.

---
*PR created automatically by Jules for task [16081397200049534231](https://jules.google.com/task/16081397200049534231) started by @ManupaKDU*