### PR TITLE
⚡ Add vTaskDelay to File IO loop to prevent blocking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -112,3 +112,6 @@
 ## 2024-05-24 - O(N) strlen overhead for boolean empty checks
 **Learning:** Checking if a string is empty or has a minimal length using `strlen(str) > 0` or `strlen(str) > 1` forces an O(N) traversal of the string, which is inefficient, especially when checking many dynamically parsed strings like HTTP parameters or parsed JSON keys.
 **Action:** Replace length boundary checks with O(1) direct character evaluations utilizing boolean short-circuiting. Use `str[0] != '\0'` instead of `strlen(str) > 0` and `str[0] != '\0' && str[1] != '\0'` instead of `strlen(str) > 1`.
+## 2024-05-18 - Avoid blocking loops in File IO
+**Learning:** In ESP32/FreeRTOS systems, tight loops reading/writing large chunks to/from slow hardware (like SD cards) will block the current task, potentially triggering Watchdog timeouts and starving other system processes.
+**Action:** Always insert `vTaskDelay(1)` or `yield()` inside heavy processing loops (like chunked file IO) to allow other tasks to execute.

--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -73,6 +73,7 @@ void saveRamLog(const char* ramLogName) {
     if (chunkSize > 0) ramFile.write((uint8_t*)messageLog + startPtr, chunkSize);
     startPtr += chunkSize;
     if (startPtr >= RAM_LOG_LEN) startPtr = 0;
+    vTaskDelay(1);
   } while (startPtr != endPtr);
   ramFile.close();
 }


### PR DESCRIPTION
💡 **What:** Added `vTaskDelay(1)` inside the `do-while` loop in `saveRamLog` (`utilsLog.cpp`).

🎯 **Why:** To prevent the chunked file I/O operations from starving other FreeRTOS tasks and triggering potential Watchdog timeouts during large log dumps to the SD card. Yielding execution keeps the system responsive.

📊 **Measured Improvement:** Because this relies on hardware SD card IO on an ESP32, local host-based unit test benchmarking is impractical. However, the theoretical benefit is undeniable: it converts a fully blocking operation into one that yields to the OS every chunk, dramatically improving multi-tasking latency at the slight cost of wall-clock dump time.

---
*PR created automatically by Jules for task [15513541803028077749](https://jules.google.com/task/15513541803028077749) started by @ManupaKDU*