### PR TITLE
⚡ Replace Arduino delay with vTaskDelay in RTSP audio loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -112,3 +112,6 @@
 ## 2024-05-24 - O(N) strlen overhead for boolean empty checks
 **Learning:** Checking if a string is empty or has a minimal length using `strlen(str) > 0` or `strlen(str) > 1` forces an O(N) traversal of the string, which is inefficient, especially when checking many dynamically parsed strings like HTTP parameters or parsed JSON keys.
 **Action:** Replace length boundary checks with O(1) direct character evaluations utilizing boolean short-circuiting. Use `str[0] != '\0'` instead of `strlen(str) > 0` and `str[0] != '\0' && str[1] != '\0'` instead of `strlen(str) > 1`.
+## 2024-05-24 - Replace delay with vTaskDelay in FreeRTOS tasks
+**Learning:** Arduino's `delay()` function introduces overhead such as watchdog resets, `yieldIfNecessary()`, and busy-waiting via `micros()` to ensure exact delays.
+**Action:** When working in FreeRTOS tasks on ESP32, replace `delay(ms)` with native `vTaskDelay(pdMS_TO_TICKS(ms))` to properly place the task in the Blocked state and free CPU cycles for other tasks.

--- a/rtsp.cpp
+++ b/rtsp.cpp
@@ -131,7 +131,7 @@ static void sendRTSPAudio(void* p) {
       rtspServer.sendRTSPAudio((int16_t*)audioBuffer, audioBytes);
       audioBytes = 0;
     } 
-    delay(20);
+    vTaskDelay(pdMS_TO_TICKS(20));
   }
 #endif
   vTaskDelete(NULL);


### PR DESCRIPTION
💡 **What:** Replaced the synchronous `delay(20);` call with FreeRTOS native `vTaskDelay(pdMS_TO_TICKS(20));` in the `sendRTSPAudio` loop in `rtsp.cpp`.

🎯 **Why:** The Arduino `delay()` function contains overhead such as watchdog resets, `yieldIfNecessary()`, and busy-waiting via `micros()` to ensure exact delays. Using `vTaskDelay` places the task directly in the Blocked state without this overhead, explicitly conforming to RTOS idioms and freeing CPU cycles for other tasks.

📊 **Measured Improvement:** Direct benchmarking is impractical since the execution occurs within a Linux sandbox and executing ESP32-specific code isn't possible. However, the use of `vTaskDelay` is a well-known optimization for FreeRTOS tasks to prevent busy-waiting and reduce CPU overhead compared to Arduino's `delay()` wrapper.

---
*PR created automatically by Jules for task [6436925979196439784](https://jules.google.com/task/6436925979196439784) started by @ManupaKDU*