### PR TITLE
🎨 Palette: Add contextual tooltips to disabled interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,7 @@
 ## 2024-07-24 - Dynamic element accessibility
 **Learning:** Automatically generated form fields (like toggle switches generated via `common.js`) often lack descriptive context (like a `title` or `aria-label`) that screen readers and power users rely on, since the HTML isn't hand-coded.
 **Action:** When working with JS-rendered components, always ensure that dynamic attributes (e.g., using the setting's key name) are injected into the template string to maintain accessibility.
+
+## 2025-01-20 - Dynamic Tooltips for Disabled States
+**Learning:** When interactive elements (like buttons) are disabled, removing their tooltip or leaving a default action tooltip is confusing. Users need to know *why* an element is disabled.
+**Action:** Update the `disable()` JavaScript helper to accept and set an optional `title` parameter explaining the disabled state, and update `enable()` to restore the original action tooltip.

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -2132,7 +2132,7 @@
         playbackButton.innerHTML = "➤&nbsp;Start Playback";
         playbackButton.setAttribute("aria-label", "Start Playback");
         playbackButton.classList.remove("blinking");
-        disable(playbackButton);
+        disable(playbackButton, "Select a .avi video to activate playback");
         stopAll("deactivatePlaybackButton");
         if (sendStop) sendAll("stopPlaying", 1);
       }
@@ -2328,23 +2328,23 @@
           $('#upload').value = filePath; //Store file path for file server upload
           pathDir = filePath.substring(0, filePath.lastIndexOf("/"));
 
-          enable($('#upload'));
-          enable($('#delete'));
+          enable($('#upload'), "Upload selected file/folder to Fileserver");
+          enable($('#delete'), "Delete selected file/folder from SD card");
           if (filePath.includes('.')) {
-            enable($('#download'));
+            enable($('#download'), "Download selected file from SD card");
           } else {
-            disable($('#download'));
+            disable($('#download'), "Select a file to enable download");
           }
         } else {
-          disable($('#download'));
-          disable($('#upload'));
-          disable($('#delete'));
+          disable($('#download'), "Select a file to enable download");
+          disable($('#upload'), "Select a file or folder to enable upload");
+          disable($('#delete'), "Select a file or folder to enable delete");
         }
         if (pathDir == "") $$('#sfile option:not(:first-child)').forEach(el => { el.remove()});
         if (filePath.substr(-4) === '.avi') {
-          if (!isActive(playbackButton)) enable(playbackButton);
+          if (!isActive(playbackButton)) enable(playbackButton, "Start Playback");
         } else {
-          if (!isActive(playbackButton)) disable(playbackButton);
+          if (!isActive(playbackButton)) disable(playbackButton, "Select a .avi video to activate playback");
         }
         if (fromUser) getFiles(filePath);
         return false;
@@ -2409,12 +2409,12 @@
 
       function micState(value) {
         value > 0 ? enableRangeSlider($('#micGain')) : disableRangeSlider($('#micGain'));
-        value > 0 ? enable($('#spkrRem')) : disable($('#spkrRem'))
+        value > 0 ? enable($('#spkrRem'), "Speaker Control") : disable($('#spkrRem'), "Speaker requires SD card pin configured")
       }
 
       function spkrState(value) {
         value > 0 ? enableRangeSlider($('#ampVol')) : disableRangeSlider($('#ampVol'));
-        value > 0 ? enable($('#micRem')) : disable($('#micRem'));
+        value > 0 ? enable($('#micRem'), "Microphone Control") : disable($('#micRem'), "Microphone requires SD card pin configured");
       }
 
       /************** RC ****************/
@@ -2586,8 +2586,8 @@
         disableRangeSlider($('#camTilt'));
         disableRangeSlider($('#camPan'));
         disableRangeSlider($('#lampLevel'));
-        disable($('#micRem'));
-        disable($('#spkrRem'));
+        disable($('#micRem'), "Microphone requires SD card pin configured");
+        disable($('#spkrRem'), "Speaker requires SD card pin configured");
         closedTab(false);
       }
 

--- a/data/common.js
+++ b/data/common.js
@@ -466,16 +466,18 @@
           el.style.display = "";
         }
 
-        function disable(el) {
+        function disable(el, title) {
           el.classList.add('disabled');
           el.disabled = true;
           el.setAttribute('aria-disabled', 'true');
+          if (title) el.title = title;
         }
 
-        function enable(el) {
+        function enable(el, title) {
           el.classList.remove('disabled');
           el.disabled = false;
           el.removeAttribute('aria-disabled');
+          if (title) el.title = title;
         }
 
         function disableRangeSlider(el) {
@@ -930,12 +932,12 @@
         const refreshBtn = document.getElementById('refreshAllButton');
         if (ipAddresses.length === 0) {
           container.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 2rem; color: var(--itemInactive); font-style: italic;">No cameras added yet. Enter an IP address above to add your first camera.</div>';
-          if (clearBtn) disable(clearBtn);
-          if (refreshBtn) disable(refreshBtn);
+          if (clearBtn) disable(clearBtn, "No saved cameras to remove");
+          if (refreshBtn) disable(refreshBtn, "No cameras to refresh");
           return;
         }
-        if (clearBtn) enable(clearBtn);
-        if (refreshBtn) enable(refreshBtn);
+        if (clearBtn) enable(clearBtn, "Remove all saved cameras");
+        if (refreshBtn) enable(refreshBtn, "Refresh all camera streams");
 
         // Convert the array of IP addresses into individual IPs
         for (const ip of ipAddresses) {


### PR DESCRIPTION
* 💡 What: Updated `disable()` and `enable()` UI helpers to dynamically set context-aware tooltips explaining disabled states and restoring them when enabled.
* 🎯 Why: To improve accessibility and user experience, so users understand *why* a button cannot be clicked.
* 📸 Before/After: Before, buttons remained disabled with no indication or retained their active action tooltip. After, they clearly explain the prerequisite to enable them.
* ♿ Accessibility: Improves screen reader and keyboard user context on interactive controls.

---
*PR created automatically by Jules for task [6147350609619306705](https://jules.google.com/task/6147350609619306705) started by @ManupaKDU*