### PR TITLE
🎨 Palette: Add Enter key support for Camera Hub IP input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2025-01-20 - Dynamic Tooltips for Disabled States
 **Learning:** When interactive elements (like buttons) are disabled, removing their tooltip or leaving a default action tooltip is confusing. Users need to know *why* an element is disabled.
 **Action:** Update the `disable()` JavaScript helper to accept and set an optional `title` parameter explaining the disabled state, and update `enable()` to restore the original action tooltip.
+## 2024-07-29 - Missing Enter Key Support in Standalone Inputs
+**Learning:** In HTML interfaces that don't wrap inputs in standard `<form>` tags, users lose the default 'Enter to submit' behavior, causing frustrating interaction dead-ends.
+**Action:** Always explicitly bind `onkeydown` event handlers checking for `event.key === 'Enter'` to critical standalone input fields to restore expected keyboard behavior.

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1760,7 +1760,7 @@
       <div id="buttonContainer">
         <!-- Input field for users to enter individual IPs -->
         <label for="ipInput">Enter IP address:&nbsp;</label>
-        <input type="text" id="ipInput" class="local" placeholder="e.g. 192.168.1.100">
+        <input type="text" id="ipInput" class="local" placeholder="e.g. 192.168.1.100" onkeydown="if(event.key === 'Enter') addIP()">
         <button id="addIpButton" class="local" onclick="addIP()" title="Add a new camera to the Hub" aria-label="Add entered IP address to Camera Hub">Add IP</button>
         <button id="clearStorageButton" class="local" onclick="clearLocalStorage()" title="Remove all saved cameras" aria-label="Delete all saved camera IP addresses">Delete All</button>
         <button id="refreshAllButton" class="local" onclick="refreshAllContainers(true)" title="Refresh all camera streams" aria-label="Refresh all camera images">Refresh</button>


### PR DESCRIPTION
💡 What: Added an `onkeydown` event handler to the `ipInput` field to trigger the `addIP()` function when the Enter key is pressed.
🎯 Why: To improve usability and keyboard accessibility. Users naturally press Enter after typing an IP address, but since the input wasn't part of a form, nothing happened.
📸 Before/After: Before: Pressing Enter in the IP input did nothing. After: Pressing Enter immediately adds the IP address.
♿ Accessibility: Improves keyboard navigation and usability for users who rely on the keyboard.

---
*PR created automatically by Jules for task [6716634062781858679](https://jules.google.com/task/6716634062781858679) started by @ManupaKDU*