### PR TITLE
⚡ Bolt: Optimize smtp subject building to eliminate O(N) strlen overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -120,3 +120,6 @@
 ## 2024-05-24 - Replace delay with vTaskDelay in FreeRTOS tasks
 **Learning:** Arduino's `delay()` function introduces overhead such as watchdog resets, `yieldIfNecessary()`, and busy-waiting via `micros()` to ensure exact delays.
 **Action:** When working in FreeRTOS tasks on ESP32, replace `delay(ms)` with native `vTaskDelay(pdMS_TO_TICKS(ms))` to properly place the task in the Blocked state and free CPU cycles for other tasks.
+## 2024-11-20 - Replace redundant strncpy+strlen with a single snprintf
+**Learning:** Using `strncpy` followed by `snprintf` with `strlen()` to append strings (e.g., `strncpy(subject, _subject, sizeof(subject)-1); snprintf(subject+strlen(subject), ...);`) causes redundant O(N) string traversals and creates potential buffer overruns.
+**Action:** Combine multi-step string building operations into a single bounded `snprintf(dest, sizeof(dest), "%s from %s", _subject, hostName)` to eliminate redundant string length calculations.

--- a/smtp.cpp
+++ b/smtp.cpp
@@ -172,8 +172,8 @@ void emailAlert(const char* _subject, const char* _message) {
   if (smtpUse) {
     if (alertBuffer != NULL) {
       if (emailHandle == NULL) {
-        strncpy(subject, _subject, sizeof(subject)-1);
-        snprintf(subject+strlen(subject), sizeof(subject)-strlen(subject), " from %s", hostName);
+        // ⚡ Bolt optimization: Combine string building into a single snprintf to eliminate O(N) strlen overhead and zero-padding
+        snprintf(subject, sizeof(subject), "%s from %s", _subject, hostName);
         strncpy(message, _message, sizeof(message)-1);
         xTaskCreateWithCaps(&emailTask, "emailTask", EMAIL_STACK_SIZE, NULL, EMAIL_PRI, &emailHandle, STACK_MEM);
         debugMemory("emailAlert");


### PR DESCRIPTION
💡 What: Replaced `strncpy` followed by `snprintf` with `strlen` with a single `snprintf` when building the email subject in `smtp.cpp`. Added a performance comment explaining the change.
🎯 Why: Using `strlen` to find the end of a buffer immediately after a string copy causes an unnecessary O(N) traversal. A single `snprintf` is more efficient, cleaner, and avoids Schlemiel the Painter's Algorithm. It also removes the risk of a buffer overrun if `strncpy` failed to null-terminate the copied string.
📊 Impact: Reduces string overhead, unnecessary O(N) operations, and improves safety during email alert generation.
🔬 Measurement: Verify compilation and observe that the email subject builds correctly and faster.

---
*PR created automatically by Jules for task [10177234748866614232](https://jules.google.com/task/10177234748866614232) started by @ManupaKDU*