### PR TITLE
🎨 Palette: Enhance mobile input UX and screen reader flow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-29 - Mobile Input and A11y Redundancy
+**Learning:** Mobile keyboards can erroneously autocorrect or autocapitalize configuration inputs like hostnames and passwords. Also, range sliders inherently announce their values to screen readers, so visually displaying the bounds and current value as separate DOM elements without `aria-hidden="true"` creates redundant and confusing speech output.
+**Action:** Always add `autocorrect="off" autocapitalize="none" spellcheck="false"` to non-prose text inputs (like configurations or URLs). Always add `aria-hidden="true"` to visual labels associated with input elements that already provide their own a11y semantics (like range sliders).

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -4,8 +4,9 @@
   s60sc 2022, 2023, 2025
   with ideas from @marekful
 -->
-<html>
+<html lang="en">
   <head>
+    <meta name="theme-color" content="#181818">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>ESP32-CAM_MJPEG2SD</title>
@@ -1368,11 +1369,11 @@
                   </div>
                   <div class="input-group" id="wifi-group">
                     <label for="hostName">Host Name</label>
-                    <input id="hostName" name="hostName" maxlength=32 placeholder="Host name">
+                    <input id="hostName" name="hostName" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="Host name">
                   </div>
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_SSID">SSID</label>
-                    <input id="ST_SSID" name="ST_SSID" maxlength=32 placeholder="Router SSID">
+                    <input id="ST_SSID" name="ST_SSID" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="Router SSID">
                   </div>
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_Pass">Password</label>
@@ -1389,7 +1390,7 @@
                   <div class="subheader">Clock settings</div>
                   <div class="input-group" id="time-group">
                     <label for="timezone">Time Zone</label>
-                    <input id="timezone" name="timezone" maxlength=64 placeholder="Time zone string">
+                    <input id="timezone" name="timezone" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=64 placeholder="Time zone string">
                   </div>
                   <div class="input-group" id="time-group">
                     <label for="regionSel">Select Region</label>
@@ -1407,15 +1408,15 @@
                   <div class="subheader">FTP / HTTPS settings</div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsServer">File Server</label>
-                    <input id="fsServer" name="fsServer" maxlength=32 placeholder="File server name">
+                    <input id="fsServer" name="fsServer" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="File server name">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsPort">FS port</label>
-                    <input id="fsPort" name="fsPport" maxlength=6 placeholder="File server port">
+                    <input id="fsPort" name="fsPport" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=6 placeholder="File server port">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="ftpUser">FTP user name</label>
-                    <input id="ftpUser" name="ftpUser" maxlength=32 placeholder="FTP user name">
+                    <input id="ftpUser" name="ftpUser" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="FTP user name">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="FS_Pass">FS password</label>
@@ -1426,7 +1427,7 @@
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsWd">FS root dir</label>
-                    <input id="fsWd" name="fsWd" maxlength=64 placeholder="Working directory path">
+                    <input id="fsWd" name="fsWd" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=64 placeholder="Working directory path">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsUse">Upload method:</label>FTP&nbsp;
@@ -1439,15 +1440,15 @@
                   <div class="subheader">SMTP settings</div>
                   <div class="input-group" id="smtp-group">
                     <label for="smtp_server">SMTP server</label>
-                    <input id="smtp_server" name="smtp_server" maxlength=32 placeholder="smtp server name">
+                    <input id="smtp_server" name="smtp_server" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="smtp server name">
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="smtp_port">SMTP port</label>
-                    <input id="smtp_port" name="smtp_port" maxlength=6 placeholder="smtp port">
+                    <input id="smtp_port" name="smtp_port" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=6 placeholder="smtp port">
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="smtp_login">SMTP login</label>
-                    <input id="smtp_login" name="smtp_login" maxlength=32 placeholder="smtp login email">
+                    <input id="smtp_login" name="smtp_login" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="smtp login email">
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="SMTP_Pass">SMTP password</label>
@@ -1458,13 +1459,13 @@
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="smtp_email">SMTP email</label>
-                    <input id="smtp_email" name="smtp_email" maxlength=64 placeholder="smtp email to">
+                    <input id="smtp_email" name="smtp_email" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=64 placeholder="smtp email to">
                   </div>
                   <br>
                   <div class="subheader">Authentication settings</div>
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Name">Web login</label>
-                      <input id="Auth_Name" name="Auth_Name" maxlength=32 placeholder="Authentication user name">
+                      <input id="Auth_Name" name="Auth_Name" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="Authentication user name">
                   </div>
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Pass">Web password</label>

--- a/data/common.js
+++ b/data/common.js
@@ -298,9 +298,9 @@
             if (el.classList.contains('vertical')) el.style.transform = 'rotate(270deg)';
             else if (el.classList.contains('vertInv')) el.style.transform = 'rotate(90deg)';
             if (!el.classList.contains('ignore')) {
-              if (!isDefined(el.parentElement.children.rangeMin)) el.insertAdjacentHTML("beforebegin", '<div name="rangeMin"/>'+el.min+'</div>');
-              el.insertAdjacentHTML("afterend", '<div name="rangeVal">'+el.value+'</div>');
-              if (!isDefined(el.parentElement.children.rangeMax)) el.insertAdjacentHTML("afterend", '<div name="rangeMax"/>'+el.max+'</div>');
+              if (!isDefined(el.parentElement.children.rangeMin)) el.insertAdjacentHTML("beforebegin", '<div name="rangeMin" aria-hidden="true">'+el.min+'</div>');
+              el.insertAdjacentHTML("afterend", '<div name="rangeVal" aria-hidden="true">'+el.value+'</div>');
+              if (!isDefined(el.parentElement.children.rangeMax)) el.insertAdjacentHTML("afterend", '<div name="rangeMax" aria-hidden="true">'+el.max+'</div>');
             }
             rangeSlider(el, false);
           });
@@ -888,7 +888,7 @@
                       const range = value.substring(2).split(":");
                       inputHtml = '<div class="input-group">';
                       inputHtml += '<input type="range" class="configItem" id="' + saveKey + '" min="' + range[0] + '" max="' + range[1];
-                      inputHtml += '" step="' + range[2] + '" value="' + saveVal + '"><div name="rangeVal">' + saveVal + '</div></div>';
+                      inputHtml += '" step="' + range[2] + '" value="' + saveVal + '"><div name="rangeVal" aria-hidden="true">' + saveVal + '</div></div>';
                     break;
                     case 'S':
                       // drop down select


### PR DESCRIPTION
💡 What: Disabled autocorrect, autocapitalize, and spellcheck on configuration input fields (hostnames, URLs, etc.). Added `aria-hidden="true"` to visual min/max/value text labels corresponding to range sliders. Added `lang="en"` to HTML and a dark `theme-color` meta tag.

🎯 Why: Mobile device keyboards often incorrectly attempt to autocorrect or capitalize technical strings like SSIDs or hostnames, causing user frustration. Range sliders natively announce their bounds and value to screen readers, so visually echoing these values with raw DOM elements creates redundant, confusing double-announcements for visually impaired users. Theme color and language definition are web application best practices.

📸 Before/After: Visual presentation is unmodified. Code changes affect meta configuration and ARIA semantics.

♿ Accessibility: Significantly declutters screen reader traversal through the dense configuration menus by silencing the redundant visual marker elements for range inputs. Setting `lang="en"` ensures screen readers apply correct pronunciation rules.

---
*PR created automatically by Jules for task [8154308232835797945](https://jules.google.com/task/8154308232835797945) started by @ManupaKDU*