### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow in mqtt_uri

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -175,3 +175,8 @@
 **Vulnerability:** A critical buffer overflow risk existed in `prefs.cpp` where `strcpy(value, configs[keyPos][1].c_str())` was used to copy configuration strings into a statically sized `value` buffer. This function was called across different parts of the code with varying sized destination buffers (e.g., `appId[16]`, `fsizePtrStr[4]`). Since configuration values from flash/SD are essentially untrusted input, a maliciously crafted config file could overflow these local arrays on the stack or BSS, potentially achieving remote code execution.
 **Learning:** Centralized configuration retrieval functions (`retrieveConfigVal`) must always enforce buffer bounds, because the size of the destination buffer is not known at the function definition site and changes depending on the caller context.
 **Prevention:** Always mandate a `size_t bufferSize` parameter for configuration retrieval functions and use bounded string operations (`strncpy` followed by explicit null termination) to ensure the destination buffer is never overflowed, regardless of how large the stored configuration value is.
+
+## 2024-06-25 - [HIGH] Buffer Overflow in mqtt_uri
+**Vulnerability:** In `mqtt.cpp`, an unbounded `sprintf` was used to concatenate `mqtt_broker` and `mqtt_port` into `mqtt_uri`. While `mqtt_uri` was correctly sized `FILE_NAME_LEN`, `sprintf` does not inherently enforce boundaries.
+**Learning:** `sprintf` inherently lacks bounds checking on the destination buffer. External inputs like MQTT payloads should never be copied into bounded arrays without proper length checks.
+**Prevention:** In C/C++, `sprintf` should be aggressively deprecated in favor of `snprintf` which guarantees bounds are respected.

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -253,7 +253,7 @@ void startMqttClient(void){
   }
   
   char mqtt_uri[FILE_NAME_LEN];
-  sprintf(mqtt_uri, "mqtt://%s:%s", mqtt_broker, mqtt_port);
+  snprintf(mqtt_uri, FILE_NAME_LEN, "mqtt://%s:%s", mqtt_broker, mqtt_port);
   snprintf(lwt_topic, FILE_NAME_LEN, "%ssensor/%s/lwt", mqtt_topic_prefix, hostName);
   snprintf(cmd_topic, FILE_NAME_LEN, "%ssensor/%s/cmd", mqtt_topic_prefix, hostName);
   snprintf(image_topic, FILE_NAME_LEN, "%ssensor/%s/still", mqtt_topic_prefix, hostName);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Buffer overflow risk due to unbounded `sprintf` in `mqtt.cpp`.
🎯 Impact: Could allow memory corruption if `mqtt_broker` and `mqtt_port` are maliciously crafted.
🔧 Fix: Replaced `sprintf` with `snprintf`.
✅ Verification: Compiled and ran tests to verify functionality.

---
*PR created automatically by Jules for task [11838720798195641114](https://jules.google.com/task/11838720798195641114) started by @ManupaKDU*