### PR TITLE
🎨 Palette: Improve accessibility and mobile input for configuration fields

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1140,7 +1140,7 @@
                     <label for="aec2" id="aec2_lab">AEC DSP</label>
                     <div class="switch">
                       <input id="aec2" type="checkbox" checked="checked">
-                      <label title="AEC DSP" class="slider" for="aec2"></label>
+                      <label title="AEC DSP" class="slider" aria-hidden="true" for="aec2"></label>
                     </div>
                   </div>
                   <div class="input-group hidden" id="agc_gain-group">
@@ -1153,14 +1153,14 @@
                     <label for="hmirror">H-Mirror</label>
                     <div class="switch">
                       <input id="hmirror" type="checkbox" checked="checked">
-                      <label title="Horizontal Mirror" class="slider" for="hmirror"></label>
+                      <label title="Horizontal Mirror" class="slider" aria-hidden="true" for="hmirror"></label>
                     </div>
                   </div>
                   <div class="input-group" id="vflip-group">
                     <label for="vflip">V-Flip</label>
                     <div class="switch">
                       <input id="vflip" type="checkbox" checked="checked">
-                      <label title="Vertical Flip" class="slider" for="vflip"></label>
+                      <label title="Vertical Flip" class="slider" aria-hidden="true" for="vflip"></label>
                     </div>
                   </div>
                   <div class="ALLOV hidden">
@@ -1168,21 +1168,21 @@
                         <label for="awb">AWB Enable</label>
                         <div class="switch">
                             <input id="awb" type="checkbox" checked="checked">
-                            <label title="AWB" class="slider" for="awb"></label>
+                            <label title="AWB" class="slider" aria-hidden="true" for="awb"></label>
                         </div>
                     </div>
                     <div class="input-group" id="awb_gain-group">
                       <label for="awb_gain" id="awbg_lab">AWB Gain</label>
                       <div class="switch">
                         <input id="awb_gain" type="checkbox" checked="checked">
-                        <label title="AWB Gain" class="slider" for="awb_gain"></label>
+                        <label title="AWB Gain" class="slider" aria-hidden="true" for="awb_gain"></label>
                       </div>
                     </div>
                     <div class="input-group" id="aec-group">
                       <label for="aec">AEC Enable</label>
                       <div class="switch">
                         <input id="aec" type="checkbox" checked="checked">
-                        <label title="AEC Sensor" class="slider" for="aec"></label>
+                        <label title="AEC Sensor" class="slider" aria-hidden="true" for="aec"></label>
                       </div>
                     </div>
                     <div class="input-group" id="ae_level-group">
@@ -1193,14 +1193,14 @@
                       <label for="dcw" id="dcw_lab">DCW (Downsize)</label>
                       <div class="switch">
                         <input id="dcw" type="checkbox" checked="checked">
-                        <label title="DCW (Downsize EN)" class="slider" for="dcw"></label>
+                        <label title="DCW (Downsize EN)" class="slider" aria-hidden="true" for="dcw"></label>
                       </div>
                     </div>
                     <div class="input-group" id="agc-group">
                       <label for="agc">AGC Enable</label>
                       <div class="switch">
                         <input id="agc" type="checkbox" checked="checked">
-                        <label title="AGC" class="slider" for="agc"></label>
+                        <label title="AGC" class="slider" aria-hidden="true" for="agc"></label>
                       </div>
                     </div>
                     <div class="input-group" id="gainceiling-group">
@@ -1213,35 +1213,35 @@
                       <label for="lenc">Lens Correction</label>
                       <div class="switch">
                         <input id="lenc" type="checkbox" checked="checked">
-                        <label title="Lens Correction" class="slider" for="lenc"></label>
+                        <label title="Lens Correction" class="slider" aria-hidden="true" for="lenc"></label>
                       </div>
                     </div>
                     <div class="input-group" id="colorbar-group">
                       <label for="colorbar">Color Bar</label>
                       <div class="switch">
                         <input id="colorbar" type="checkbox">
-                        <label title="Color Bar" class="slider" for="colorbar"></label>
+                        <label title="Color Bar" class="slider" aria-hidden="true" for="colorbar"></label>
                       </div>
                     </div>
                     <div class="input-group" id="bpc-group">
                       <label for="bpc">BPC</label>
                       <div class="switch">
                         <input id="bpc" type="checkbox" checked="checked">
-                        <label title="BPC" class="slider" for="bpc"></label>
+                        <label title="BPC" class="slider" aria-hidden="true" for="bpc"></label>
                       </div>
                     </div>
                     <div class="input-group" id="wpc-group">
                       <label for="wpc">WPC</label>
                       <div class="switch">
                         <input id="wpc" type="checkbox" checked="checked">
-                        <label title="WPC" class="slider" for="wpc"></label>
+                        <label title="WPC" class="slider" aria-hidden="true" for="wpc"></label>
                       </div>
                     </div>
                     <div class="input-group" id="raw_gma-group">
                       <label for="raw_gma">GMA Enable</label>
                       <div class="switch">
                         <input id="raw_gma" type="checkbox" checked="checked">
-                        <label title="Raw GMA" class="slider" for="raw_gma"></label>
+                        <label title="Raw GMA" class="slider" aria-hidden="true" for="raw_gma"></label>
                       </div>
                     </div>
                   </div>
@@ -1258,7 +1258,7 @@
                     <label for="enableMotion">Motion Detect</label>
                     <div class="switch">
                       <input id="enableMotion" type="checkbox">
-                      <label title="Enable/disable motion detection" class="slider" for="enableMotion"></label>
+                      <label title="Enable/disable motion detection" class="slider" aria-hidden="true" for="enableMotion"></label>
                     </div>
                   </div>
                   <div class="input-group" id="motion-group">
@@ -1273,14 +1273,14 @@
                       <label for="record">Save Capture</label>
                       <div class="switch">
                         <input id="record" type="checkbox">
-                        <label title="Enable recording on motion detection" class="slider" for="record"></label>
+                        <label title="Enable recording on motion detection" class="slider" aria-hidden="true" for="record"></label>
                       </div>
                   </div>
                   <div class="input-group" id="dbgMotion-group">
                     <label for="dbgMotion">Show Motion</label>
                     <div class="switch">
                       <input id="dbgMotion" type="checkbox">
-                      <label title="Display detected camera motion" class="slider" for="dbgMotion"></label>
+                      <label title="Display detected camera motion" class="slider" aria-hidden="true" for="dbgMotion"></label>
                     </div>
                   </div>
                   <div class="input-group" id="lswitch-group">
@@ -1292,7 +1292,7 @@
                     <label for="timeLapseOn">Time Lapse</label>
                     <div class="switch">
                       <input id="timeLapseOn" type="checkbox">
-                      <label title="Enable time lapse recording" class="slider" for="timeLapseOn"></label>
+                      <label title="Enable time lapse recording" class="slider" aria-hidden="true" for="timeLapseOn"></label>
                     </div>
                   </div>
                   <div class="input-group" id="dcam-group">
@@ -1331,7 +1331,7 @@
                     <label for="useFtps">Use FTPS</label>
                     <div class="switch">
                       <input id="useFtps" type="checkbox">
-                      <label title="Use FTPS instead of FTP" class="slider" for="useFtps"></label>
+                      <label title="Use FTPS instead of FTP" class="slider" aria-hidden="true" for="useFtps"></label>
                     </div>
                   </div>
   -->
@@ -1339,14 +1339,14 @@
                     <label for="autoUpload">Auto upload</label>
                     <div class="switch">
                       <input id="autoUpload" type="checkbox">
-                      <label title="Automatic upload to file server on file creation" class="slider" for="autoUpload"></label>
+                      <label title="Automatic upload to file server on file creation" class="slider" aria-hidden="true" for="autoUpload"></label>
                     </div>
                   </div>
                   <div class="input-group" id="deleteAfter-group">
                     <label for="deleteAfter">Auto SD Delete</label>
                     <div class="switch">
                       <input id="deleteAfter" type="checkbox">
-                      <label title="Automatic deletion on SD after file server upload" class="slider" for="deleteAfter"></label>
+                      <label title="Automatic deletion on SD after file server upload" class="slider" aria-hidden="true" for="deleteAfter"></label>
                     </div>
                   </div>
                 </div>
@@ -1378,7 +1378,7 @@
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
+                      <input type="password" id="ST_Pass" name="ST_Pass" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="togglePassword(this, 'ST_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1421,7 +1421,7 @@
                   <div class="input-group" id="ftp-group">
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
+                      <input type="password" id="FS_Pass" name="FS_Pass" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="togglePassword(this, 'FS_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1433,7 +1433,7 @@
                     <label for="fsUse">Upload method:</label>FTP&nbsp;
                     <div class="switch">
                       <input id="fsUse" type="checkbox">
-                      <label title="Upload file using FTP or HFS" class="slider" for="fsUse"></label>
+                      <label title="Upload file using FTP or HFS" class="slider" aria-hidden="true" for="fsUse"></label>
                     </div>&nbsp;HFS
                   </div>
                   <br>
@@ -1453,7 +1453,7 @@
                   <div class="input-group" id="smtp-group">
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
+                      <input type="password" id="SMTP_Pass" name="SMTP_Pass" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="togglePassword(this, 'SMTP_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1470,7 +1470,7 @@
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
-                      <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
+                      <input type="password" id="Auth_Pass" name="Auth_Pass" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="togglePassword(this, 'Auth_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1478,14 +1478,14 @@
                     <label for="useHttps">Use HTTPS</label>
                     <div class="switch">
                       <input id="useHttps" type="checkbox">
-                      <label title="Use HTTPS to access app" class="slider" for="useHttps"></label>
+                      <label title="Use HTTPS to access app" class="slider" aria-hidden="true" for="useHttps"></label>
                     </div>
                   </div>
                   <div class="input-group" id="auth-group">
                     <label for="useSecure">Check Certs</label>
                     <div class="switch">
                       <input id="useSecure" type="checkbox">
-                      <label title="Check remote servers certificate" class="slider" for="useSecure"></label>
+                      <label title="Check remote servers certificate" class="slider" aria-hidden="true" for="useSecure"></label>
                     </div>
                   </div>
                 </div>
@@ -1605,7 +1605,7 @@
         <div class="input-group" id="dbg-group" style="text-align: right">
           <div class="switch">
             <input id="dbgVerbose" type="checkbox">
-            <label title="Outputs additional information to log" class="slider" for="dbgVerbose"></label>
+            <label title="Outputs additional information to log" class="slider" aria-hidden="true" for="dbgVerbose"></label>
           </div>
         </div>
         <br>
@@ -1615,7 +1615,7 @@
         <div class="input-group" id="dbg-group" style="text-align: right">
           <div class="switch">
             <input id="sdLog" type="checkbox">
-            <label title="Outputs log to SD card" class="slider" for="sdLog"></label>
+            <label title="Outputs log to SD card" class="slider" aria-hidden="true" for="sdLog"></label>
           </div>
         </div>
         <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="showsys">


### PR DESCRIPTION
💡 What: Added `autocorrect="off" autocapitalize="none" spellcheck="false"` to password input fields and `aria-hidden="true"` to visual slider labels.
🎯 Why: To prevent mobile keyboards from inappropriately autocorrecting configuration inputs and to reduce redundant screen reader announcements for visual labels whose associated inputs already provide semantics.
📸 Before/After: Visual presentation unchanged, DOM attributes improved for screen readers and mobile keyboards.
♿ Accessibility: Improved screen reader clarity for sliders and mobile keyboard UX for password inputs.

---
*PR created automatically by Jules for task [1726445221728900034](https://jules.google.com/task/1726445221728900034) started by @ManupaKDU*