### PR TITLE
🎨 Palette: Mobile UX & Screen Reader Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-01-29 - Mobile Input and A11y Redundancy
 **Learning:** Mobile keyboards can erroneously autocorrect or autocapitalize configuration inputs like hostnames and passwords. Also, range sliders inherently announce their values to screen readers, so visually displaying the bounds and current value as separate DOM elements without `aria-hidden="true"` creates redundant and confusing speech output.
 **Action:** Always add `autocorrect="off" autocapitalize="none" spellcheck="false"` to non-prose text inputs (like configurations or URLs). Always add `aria-hidden="true"` to visual labels associated with input elements that already provide their own a11y semantics (like range sliders).
+
+## 2024-05-24 - Improve Input Accessibility
+**Learning:** Adding aria-hidden to visual bounds reduces screen reader clutter for range sliders. Disabling auto-correct/capitalize for password inputs improves mobile UX.
+**Action:** Always verify decorative UI elements have aria-hidden and configuration inputs don't try to autocorrect on mobile.

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1106,7 +1106,7 @@
                     </div>
                     <div class="input-group" id="denoise-group">
                       <label for="denoise">De-Noise</label>
-                      <div name="rangeMin">Auto</div>
+                      <div name="rangeMin" aria-hidden="true">Auto</div>
                       <input title="Set image de-noise level" type="range" id="denoise" min="0" max="8" value="0">
                     </div>
                   </div>
@@ -1145,9 +1145,9 @@
                   </div>
                   <div class="input-group hidden" id="agc_gain-group">
                     <label for="agc_gain" id="agc_gain_lab">Gain</label>
-                    <div name="rangeMin">1x</div>
+                    <div name="rangeMin" aria-hidden="true">1x</div>
                     <input title="Set automatic gain control limit" type="range" id="agc_gain" min="0" max="30" value="5">
-                    <div name="rangeMax">31x</div>
+                    <div name="rangeMax" aria-hidden="true">31x</div>
                   </div>
                   <div class="input-group" id="hmirror-group">
                     <label for="hmirror">H-Mirror</label>
@@ -1205,9 +1205,9 @@
                     </div>
                     <div class="input-group" id="gainceiling-group">
                       <label for="gainceiling">Gain Ceiling</label>
-                      <div name="rangeMin">2x</div>
+                      <div name="rangeMin" aria-hidden="true">2x</div>
                       <input title="Set gain ceiling limit" type="range" id="gainceiling" min="0" max="6" value="0">
-                      <div name="rangeMax">128x</div>
+                      <div name="rangeMax" aria-hidden="true">128x</div>
                     </div>
                     <div class="input-group" id="lenc-group">
                       <label for="lenc">Lens Correction</label>
@@ -1378,7 +1378,7 @@
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
+                      <input type="password" autocorrect="off" autocapitalize="none" spellcheck="false" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="togglePassword(this, 'ST_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1421,7 +1421,7 @@
                   <div class="input-group" id="ftp-group">
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
+                      <input type="password" autocorrect="off" autocapitalize="none" spellcheck="false" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="togglePassword(this, 'FS_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1453,7 +1453,7 @@
                   <div class="input-group" id="smtp-group">
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
+                      <input type="password" autocorrect="off" autocapitalize="none" spellcheck="false" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="togglePassword(this, 'SMTP_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1470,7 +1470,7 @@
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
-                      <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
+                      <input type="password" autocorrect="off" autocapitalize="none" spellcheck="false" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="togglePassword(this, 'Auth_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1571,11 +1571,11 @@
               </div>
               <div class="RCcontrolFmt RCsteerFmt">
                 <input title="Control RC steering" type="range" id="steerDirection" aria-label="Steer Direction" class="RCcontrol immed bigThumb ignore" value=0>
-                <div name="rangeVal" style="top: 2px" class="rvThumb">0</div>
+                <div name="rangeVal" aria-hidden="true" style="top: 2px" class="rvThumb">0</div>
               </div>
               <div class="RCcontrolFmt RCmotorFmt">
                 <input title="Control RC speed" type="range" id="motorSpeed" aria-label="Motor Speed" class="RCcontrol immed bigThumb ignore" value=0>
-                <div name="rangeVal" class="rvThumb">0</div>
+                <div name="rangeVal" aria-hidden="true" class="rvThumb">0</div>
               </div>
             </div>
             <img id="stream" src="" crossorigin alt="Live camera stream">


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to visual bound labels (`rangeMin`, `rangeMax`, `rangeVal`) for range sliders. Added `autocorrect="off"`, `autocapitalize="none"`, and `spellcheck="false"` attributes to all password inputs.
🎯 Why: Prevents mobile keyboards from erroneously modifying or autocapitalizing configuration inputs like passwords. Stops screen readers from redundantly announcing visual range slider bounds alongside the slider itself.
📸 Before/After: Visuals remain unchanged, but the underlying DOM elements are updated for screen readers and mobile keyboards.
♿ Accessibility: Reduces screen reader clutter for range inputs and prevents mobile text correction interference on password fields.

---
*PR created automatically by Jules for task [15647629135386417783](https://jules.google.com/task/15647629135386417783) started by @ManupaKDU*