### PR TITLE
🎨 Palette: Add accessibility attributes and keyboard navigation

### DIFF
--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -864,16 +864,16 @@
                   </div>
                   <div class="input-group" id="wifi-group">
                     <label for="hostName">Host Name</label>
-                    <input id="hostName" name="hostName" maxlength=32 placeholder="Host name">
+                    <input id="hostName" name="hostName" maxlength=32 placeholder="Host name" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_SSID">SSID</label>
-                    <input id="ST_SSID" name="ST_SSID" maxlength=32 placeholder="Router SSID">
+                    <input id="ST_SSID" name="ST_SSID" maxlength=32 placeholder="Router SSID" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
+                      <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%" autocorrect="off" autocapitalize="none" spellcheck="false">
                       <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -885,7 +885,7 @@
                   <div class="subheader">Clock settings</div>
                   <div class="input-group" id="time-group">
                     <label for="timezone">Time Zone</label>
-                    <input id="timezone" name="timezone" maxlength=64 placeholder="Time zone string">
+                    <input id="timezone" name="timezone" maxlength=64 placeholder="Time zone string" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group" id="time-group">
                     <label for="regionSel">Select Region</label>
@@ -903,26 +903,26 @@
                   <div class="subheader">FTP / HTTPS settings</div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsServer">File Server</label>
-                    <input id="fsServer" name="fsServer" maxlength=32 placeholder="File server name">
+                    <input id="fsServer" name="fsServer" maxlength=32 placeholder="File server name" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsPort">FS port</label>
-                    <input id="fsPort" name="fsPport" maxlength=6 placeholder="File server port">
+                    <input id="fsPort" name="fsPport" maxlength=6 placeholder="File server port" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="ftpUser">FTP user name</label>
-                    <input id="ftpUser" name="ftpUser" maxlength=32 placeholder="FTP user name">
+                    <input id="ftpUser" name="ftpUser" maxlength=32 placeholder="FTP user name" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
+                      <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%" autocorrect="off" autocapitalize="none" spellcheck="false">
                       <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsWd">FS root dir</label>
-                    <input id="fsWd" name="fsWd" maxlength=64 placeholder="Working directory path">
+                    <input id="fsWd" name="fsWd" maxlength=64 placeholder="Working directory path" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsUse">Upload method:</label>FTP&nbsp;
@@ -935,37 +935,37 @@
                   <div class="subheader">SMTP settings</div>
                   <div class="input-group" id="smtp-group">
                     <label for="smtp_server">SMTP server</label>
-                    <input id="smtp_server" name="smtp_server" maxlength=32 placeholder="smtp server name">
+                    <input id="smtp_server" name="smtp_server" maxlength=32 placeholder="smtp server name" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="smtp_port">SMTP port</label>
-                    <input id="smtp_port" name="smtp_port" maxlength=6 placeholder="smtp port">
+                    <input id="smtp_port" name="smtp_port" maxlength=6 placeholder="smtp port" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="smtp_login">SMTP login</label>
-                    <input id="smtp_login" name="smtp_login" maxlength=32 placeholder="smtp login email">
+                    <input id="smtp_login" name="smtp_login" maxlength=32 placeholder="smtp login email" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
+                      <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%" autocorrect="off" autocapitalize="none" spellcheck="false">
                       <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="smtp_email">SMTP email</label>
-                    <input id="smtp_email" name="smtp_email" maxlength=64 placeholder="smtp email to">
+                    <input id="smtp_email" name="smtp_email" maxlength=64 placeholder="smtp email to" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <br>
                   <div class="subheader">Authentication settings</div>
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Name">Web login</label>
-                      <input id="Auth_Name" name="Auth_Name" maxlength=32 placeholder="Authentication user name">
+                      <input id="Auth_Name" name="Auth_Name" maxlength=32 placeholder="Authentication user name" autocorrect="off" autocapitalize="none" spellcheck="false">
                   </div>
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
-                      <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
+                      <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%" autocorrect="off" autocapitalize="none" spellcheck="false">
                       <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1057,32 +1057,32 @@
           </div>
         </div>
         <br>
-        <div tabindex="0" role="button" aria-labelledby="showsys">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="showsys">
           <svg>
             <rect class="buttonRect"/>
             <text id="showsys" class="midText">System</text>
           </svg>
         </div>
         <div style="grid-column: span 4"><br></div>
-        <div tabindex="0" role="button" aria-labelledby="refreshLog">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="refreshLog">
           <svg>
             <rect class="buttonRect"/>
             <text class="local" id="refreshLog">Refresh Log</text>
           </svg>
         </div>
-        <div tabindex="0" role="button" aria-labelledby="clearLog">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="clearLog">
           <svg>
             <rect class="buttonRect"/>
             <text class="local" id="clearLog">Clear Log</text>
           </svg>
         </div>
-        <div tabindex="0" role="button" aria-labelledby="save">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="save">
           <svg>
             <rect class="buttonRect"/>
             <text id="save" class="midText">Save</text>
           </svg>
         </div>
-        <div tabindex="0" role="button" aria-labelledby="reset">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="reset">
           <svg>
             <rect class="buttonRect"/>
             <text id="reset" class="midText">Reboot ESP</text>
@@ -1099,25 +1099,25 @@
       <div class="header">Control</div>
       <br>
       <div class="grid-cols4">
-        <div tabindex="0" role="button" aria-labelledby="save">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="save">
           <svg>
             <rect class="buttonRect"/>
             <text id="save" class="midText">Save</text>
           </svg>
         </div>
-        <div tabindex="0" role="button" aria-labelledby="reset">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="reset">
           <svg>
             <rect class="buttonRect"/>
             <text id="reset" class="midText">Reboot ESP</text>
           </svg>
         </div>
-        <div tabindex="0" role="button" aria-labelledby="deldata">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="deldata">
           <svg>
             <rect class="buttonRect"/>
             <text id="deldata" class="midText">Reload /data</text>
           </svg>
         </div>
-        <div tabindex="0" role="button" aria-labelledby="clear">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="clear">
           <svg>
             <rect class="buttonRect"/>
             <text id="clear" class="midText">Clear NVS</text>
@@ -1130,31 +1130,31 @@
           <div class="subheader">Press Save button to make changes permanent</div>
           <br>
         </div>
-        <div tabindex="0" role="button" aria-labelledby="wifi">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="wifi">
           <svg>
             <rect class="buttonRect"/>
             <text class="local midText" id="wifi">Network</text>
           </svg>
         </div>
-        <div tabindex="0" role="button" aria-labelledby="peripherals">
+        <div tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="peripherals">
           <svg>
             <rect class="buttonRect"/>
             <text class="local midText" id="peripherals">Peripherals</text>
           </svg>
         </div>
-        <div id="RCconfigBtn" class="hidden" tabindex="0" role="button" aria-labelledby="RCconfig">
+        <div id="RCconfigBtn" class="hidden" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="RCconfig">
           <svg>
             <rect class="buttonRect"/>
             <text class="local midText" id="RCconfig">RC Config</text>
           </svg>
         </div>
-        <div id="SVconfigBtn" class="hidden" tabindex="0" role="button" aria-labelledby="SVconfig">
+        <div id="SVconfigBtn" class="hidden" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="SVconfig">
           <svg>
             <rect class="buttonRect"/>
             <text class="local midText" id="SVconfig">Servos</text>
           </svg>
         </div>
-        <div id="PGconfigBtn" class="hidden" tabindex="0" role="button" aria-labelledby="PGconfig">
+        <div id="PGconfigBtn" class="hidden" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" aria-labelledby="PGconfig">
           <svg>
             <rect class="buttonRect"/>
             <text class="local midText" id="PGconfig">PG Control</text>

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1106,7 +1106,7 @@
                     </div>
                     <div class="input-group" id="denoise-group">
                       <label for="denoise">De-Noise</label>
-                      <div name="rangeMin">Auto</div>
+                      <div name="rangeMin" aria-hidden="true">Auto</div>
                       <input title="Set image de-noise level" type="range" id="denoise" min="0" max="8" value="0">
                     </div>
                   </div>
@@ -1145,9 +1145,9 @@
                   </div>
                   <div class="input-group hidden" id="agc_gain-group">
                     <label for="agc_gain" id="agc_gain_lab">Gain</label>
-                    <div name="rangeMin">1x</div>
+                    <div name="rangeMin" aria-hidden="true">1x</div>
                     <input title="Set automatic gain control limit" type="range" id="agc_gain" min="0" max="30" value="5">
-                    <div name="rangeMax">31x</div>
+                    <div name="rangeMax" aria-hidden="true">31x</div>
                   </div>
                   <div class="input-group" id="hmirror-group">
                     <label for="hmirror">H-Mirror</label>
@@ -1205,9 +1205,9 @@
                     </div>
                     <div class="input-group" id="gainceiling-group">
                       <label for="gainceiling">Gain Ceiling</label>
-                      <div name="rangeMin">2x</div>
+                      <div name="rangeMin" aria-hidden="true">2x</div>
                       <input title="Set gain ceiling limit" type="range" id="gainceiling" min="0" max="6" value="0">
-                      <div name="rangeMax">128x</div>
+                      <div name="rangeMax" aria-hidden="true">128x</div>
                     </div>
                     <div class="input-group" id="lenc-group">
                       <label for="lenc">Lens Correction</label>
@@ -1378,7 +1378,7 @@
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
+                      <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%" autocorrect="off" autocapitalize="none" spellcheck="false">
                       <span class="password-toggle local" onclick="togglePassword(this, 'ST_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1421,7 +1421,7 @@
                   <div class="input-group" id="ftp-group">
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
+                      <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%" autocorrect="off" autocapitalize="none" spellcheck="false">
                       <span class="password-toggle local" onclick="togglePassword(this, 'FS_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1453,7 +1453,7 @@
                   <div class="input-group" id="smtp-group">
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
+                      <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%" autocorrect="off" autocapitalize="none" spellcheck="false">
                       <span class="password-toggle local" onclick="togglePassword(this, 'SMTP_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1470,7 +1470,7 @@
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
-                      <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
+                      <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%" autocorrect="off" autocapitalize="none" spellcheck="false">
                       <span class="password-toggle local" onclick="togglePassword(this, 'Auth_Pass')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -1761,7 +1761,7 @@
       <div id="buttonContainer">
         <!-- Input field for users to enter individual IPs -->
         <label for="ipInput">Enter IP address:&nbsp;</label>
-        <input type="text" id="ipInput" class="local" placeholder="e.g. 192.168.1.100" onkeydown="if(event.key === 'Enter') addIP()">
+        <input type="text" id="ipInput" class="local" placeholder="e.g. 192.168.1.100" onkeydown="if(event.key === 'Enter') addIP()" autocorrect="off" autocapitalize="none" spellcheck="false">
         <button id="addIpButton" class="local" onclick="addIP()" title="Add a new camera to the Hub" aria-label="Add entered IP address to Camera Hub">Add IP</button>
         <button id="clearStorageButton" class="local" onclick="clearLocalStorage()" title="Remove all saved cameras" aria-label="Delete all saved camera IP addresses">Delete All</button>
         <button id="refreshAllButton" class="local" onclick="refreshAllContainers(true)" title="Refresh all camera streams" aria-label="Refresh all camera images">Refresh</button>


### PR DESCRIPTION
💡 What:
Added `autocorrect="off" autocapitalize="none" spellcheck="false"` to technical and configuration text/password inputs in `data/MJPEG2SD.htm` and `data/Auxil.htm`.
Added `aria-hidden="true"` to visual bounds (`rangeMin` and `rangeMax`) for range sliders.
Implemented keyboard support (`onkeydown`) for `aria-labelledby` custom buttons in `data/Auxil.htm`.

🎯 Why:
To prevent frustrating mobile keyboard corrections on technical inputs (like hostnames, passwords).
To prevent redundant screen reader announcements (as range inputs inherently declare their semantic bounds).
To ensure all custom buttons are fully accessible via keyboard.

📸 Before/After:
N/A (Non-visual behavioral/accessibility changes)

♿ Accessibility:
Improved keyboard navigability for custom div buttons. Eliminated repetitive screen reader output on slider bounds. Enhanced mobile input UX by disabling inappropriate autocorrect.

---
*PR created automatically by Jules for task [13749156668909840077](https://jules.google.com/task/13749156668909840077) started by @ManupaKDU*