### PR TITLE
🎨 Palette: Improve Mobile Accessibility and UX Redundancy

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-01-29 - Mobile Input and A11y Redundancy
 **Learning:** Mobile keyboards can erroneously autocorrect or autocapitalize configuration inputs like hostnames and passwords. Also, range sliders inherently announce their values to screen readers, so visually displaying the bounds and current value as separate DOM elements without `aria-hidden="true"` creates redundant and confusing speech output.
 **Action:** Always add `autocorrect="off" autocapitalize="none" spellcheck="false"` to non-prose text inputs (like configurations or URLs). Always add `aria-hidden="true"` to visual labels associated with input elements that already provide their own a11y semantics (like range sliders).
+## 2025-01-29 - Mobile Input Redundancy
+**Learning:** Adding `autocorrect="off" autocapitalize="none" spellcheck="false"` to non-prose text inputs improves mobile accessibility.
+**Action:** Always add `autocorrect="off" autocapitalize="none" spellcheck="false"` to non-prose text inputs (like configurations or URLs).

--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -864,16 +864,16 @@
                   </div>
                   <div class="input-group" id="wifi-group">
                     <label for="hostName">Host Name</label>
-                    <input id="hostName" name="hostName" maxlength=32 placeholder="Host name">
+                    <input id="hostName" name="hostName" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="Host name">
                   </div>
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_SSID">SSID</label>
-                    <input id="ST_SSID" name="ST_SSID" maxlength=32 placeholder="Router SSID">
+                    <input id="ST_SSID" name="ST_SSID" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="Router SSID">
                   </div>
                   <div class="input-group wifi-only" id="wifi-group">
                     <label for="ST_Pass">Password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="ST_Pass" name="ST_Pass" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
+                      <input type="password" id="ST_Pass" name="ST_Pass" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=64 placeholder="Router password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="const p=document.getElementById('ST_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for ST_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
@@ -885,7 +885,7 @@
                   <div class="subheader">Clock settings</div>
                   <div class="input-group" id="time-group">
                     <label for="timezone">Time Zone</label>
-                    <input id="timezone" name="timezone" maxlength=64 placeholder="Time zone string">
+                    <input id="timezone" name="timezone" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=64 placeholder="Time zone string">
                   </div>
                   <div class="input-group" id="time-group">
                     <label for="regionSel">Select Region</label>
@@ -903,26 +903,26 @@
                   <div class="subheader">FTP / HTTPS settings</div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsServer">File Server</label>
-                    <input id="fsServer" name="fsServer" maxlength=32 placeholder="File server name">
+                    <input id="fsServer" name="fsServer" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="File server name">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsPort">FS port</label>
-                    <input id="fsPort" name="fsPport" maxlength=6 placeholder="File server port">
+                    <input id="fsPort" name="fsPport" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=6 placeholder="File server port">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="ftpUser">FTP user name</label>
-                    <input id="ftpUser" name="ftpUser" maxlength=32 placeholder="FTP user name">
+                    <input id="ftpUser" name="ftpUser" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="FTP user name">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="FS_Pass">FS password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="FS_Pass" name="FS_Pass" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
+                      <input type="password" id="FS_Pass" name="FS_Pass" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="File server password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="const p=document.getElementById('FS_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for FS_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsWd">FS root dir</label>
-                    <input id="fsWd" name="fsWd" maxlength=64 placeholder="Working directory path">
+                    <input id="fsWd" name="fsWd" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=64 placeholder="Working directory path">
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="fsUse">Upload method:</label>FTP&nbsp;
@@ -935,37 +935,37 @@
                   <div class="subheader">SMTP settings</div>
                   <div class="input-group" id="smtp-group">
                     <label for="smtp_server">SMTP server</label>
-                    <input id="smtp_server" name="smtp_server" maxlength=32 placeholder="smtp server name">
+                    <input id="smtp_server" name="smtp_server" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="smtp server name">
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="smtp_port">SMTP port</label>
-                    <input id="smtp_port" name="smtp_port" maxlength=6 placeholder="smtp port">
+                    <input id="smtp_port" name="smtp_port" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=6 placeholder="smtp port">
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="smtp_login">SMTP login</label>
-                    <input id="smtp_login" name="smtp_login" maxlength=32 placeholder="smtp login email">
+                    <input id="smtp_login" name="smtp_login" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="smtp login email">
                   </div>
                   <div class="input-group" id="smtp-group">
                     <label for="SMTP_Pass">SMTP password</label>
                     <div class="password-wrapper">
-                      <input type="password" id="SMTP_Pass" name="SMTP_Pass" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
+                      <input type="password" id="SMTP_Pass" name="SMTP_Pass" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="smtp password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="const p=document.getElementById('SMTP_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for SMTP_Pass" title="Show password">👁️</span>
                     </div>
                   </div>
                   <div class="input-group" id="ftp-group">
                     <label for="smtp_email">SMTP email</label>
-                    <input id="smtp_email" name="smtp_email" maxlength=64 placeholder="smtp email to">
+                    <input id="smtp_email" name="smtp_email" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=64 placeholder="smtp email to">
                   </div>
                   <br>
                   <div class="subheader">Authentication settings</div>
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Name">Web login</label>
-                      <input id="Auth_Name" name="Auth_Name" maxlength=32 placeholder="Authentication user name">
+                      <input id="Auth_Name" name="Auth_Name" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="Authentication user name">
                   </div>
                   <div class="input-group" id="auth-group">
                       <label for="Auth_Pass">Web password</label>
                       <div class="password-wrapper">
-                      <input type="password" id="Auth_Pass" name="Auth_Pass" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
+                      <input type="password" id="Auth_Pass" name="Auth_Pass" autocorrect="off" autocapitalize="none" spellcheck="false" maxlength=32 placeholder="Authentication password" style="padding-right:30px; width:100%">
                       <span class="password-toggle local" onclick="const p=document.getElementById('Auth_Pass'); if(p.type==='password'){p.type='text';this.innerText='🙈';this.title='Hide password';}else{p.type='password';this.innerText='👁️';this.title='Show password';}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}" role="button" tabindex="0" aria-label="Toggle password visibility for Auth_Pass" title="Show password">👁️</span>
                     </div>
                   </div>

--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1106,7 +1106,7 @@
                     </div>
                     <div class="input-group" id="denoise-group">
                       <label for="denoise">De-Noise</label>
-                      <div name="rangeMin">Auto</div>
+                      <div name="rangeMin" aria-hidden="true">Auto</div>
                       <input title="Set image de-noise level" type="range" id="denoise" min="0" max="8" value="0">
                     </div>
                   </div>
@@ -1145,9 +1145,9 @@
                   </div>
                   <div class="input-group hidden" id="agc_gain-group">
                     <label for="agc_gain" id="agc_gain_lab">Gain</label>
-                    <div name="rangeMin">1x</div>
+                    <div name="rangeMin" aria-hidden="true">1x</div>
                     <input title="Set automatic gain control limit" type="range" id="agc_gain" min="0" max="30" value="5">
-                    <div name="rangeMax">31x</div>
+                    <div name="rangeMax" aria-hidden="true">31x</div>
                   </div>
                   <div class="input-group" id="hmirror-group">
                     <label for="hmirror">H-Mirror</label>
@@ -1205,9 +1205,9 @@
                     </div>
                     <div class="input-group" id="gainceiling-group">
                       <label for="gainceiling">Gain Ceiling</label>
-                      <div name="rangeMin">2x</div>
+                      <div name="rangeMin" aria-hidden="true">2x</div>
                       <input title="Set gain ceiling limit" type="range" id="gainceiling" min="0" max="6" value="0">
-                      <div name="rangeMax">128x</div>
+                      <div name="rangeMax" aria-hidden="true">128x</div>
                     </div>
                     <div class="input-group" id="lenc-group">
                       <label for="lenc">Lens Correction</label>
@@ -1571,11 +1571,11 @@
               </div>
               <div class="RCcontrolFmt RCsteerFmt">
                 <input title="Control RC steering" type="range" id="steerDirection" aria-label="Steer Direction" class="RCcontrol immed bigThumb ignore" value=0>
-                <div name="rangeVal" style="top: 2px" class="rvThumb">0</div>
+                <div name="rangeVal" aria-hidden="true" style="top: 2px" class="rvThumb">0</div>
               </div>
               <div class="RCcontrolFmt RCmotorFmt">
                 <input title="Control RC speed" type="range" id="motorSpeed" aria-label="Motor Speed" class="RCcontrol immed bigThumb ignore" value=0>
-                <div name="rangeVal" class="rvThumb">0</div>
+                <div name="rangeVal" aria-hidden="true" class="rvThumb">0</div>
               </div>
             </div>
             <img id="stream" src="" crossorigin alt="Live camera stream">


### PR DESCRIPTION
- 💡 What: Added `autocorrect="off" autocapitalize="none" spellcheck="false"` to non-prose text inputs in `data/Auxil.htm`. Added `aria-hidden="true"` to visual bounds labels (`rangeMin`, `rangeMax`, `rangeVal`) for range sliders in `data/MJPEG2SD.htm`.
- 🎯 Why: Mobile keyboards can erroneously autocorrect or autocapitalize configuration inputs like hostnames and passwords. Range sliders inherently announce their values to screen readers, so visually displaying the bounds and current value as separate DOM elements without `aria-hidden="true"` creates redundant and confusing speech output.
- 📸 Before/After: Visual changes are not significant, but accessibility structure is improved.
- ♿ Accessibility: Prevented redundant speech output for range sliders. Improved ease of input for configuration fields on mobile devices.

---
*PR created automatically by Jules for task [10245743677138308260](https://jules.google.com/task/10245743677138308260) started by @ManupaKDU*