### PR TITLE
🎨 Palette: A11y and mobile UX improvements

### DIFF
--- a/data/MJPEG2SD.htm
+++ b/data/MJPEG2SD.htm
@@ -1106,7 +1106,7 @@
                     </div>
                     <div class="input-group" id="denoise-group">
                       <label for="denoise">De-Noise</label>
-                      <div name="rangeMin">Auto</div>
+                      <div name="rangeMin" aria-hidden="true">Auto</div>
                       <input title="Set image de-noise level" type="range" id="denoise" min="0" max="8" value="0">
                     </div>
                   </div>
@@ -1145,9 +1145,9 @@
                   </div>
                   <div class="input-group hidden" id="agc_gain-group">
                     <label for="agc_gain" id="agc_gain_lab">Gain</label>
-                    <div name="rangeMin">1x</div>
+                    <div name="rangeMin" aria-hidden="true">1x</div>
                     <input title="Set automatic gain control limit" type="range" id="agc_gain" min="0" max="30" value="5">
-                    <div name="rangeMax">31x</div>
+                    <div name="rangeMax" aria-hidden="true">31x</div>
                   </div>
                   <div class="input-group" id="hmirror-group">
                     <label for="hmirror">H-Mirror</label>
@@ -1205,9 +1205,9 @@
                     </div>
                     <div class="input-group" id="gainceiling-group">
                       <label for="gainceiling">Gain Ceiling</label>
-                      <div name="rangeMin">2x</div>
+                      <div name="rangeMin" aria-hidden="true">2x</div>
                       <input title="Set gain ceiling limit" type="range" id="gainceiling" min="0" max="6" value="0">
-                      <div name="rangeMax">128x</div>
+                      <div name="rangeMax" aria-hidden="true">128x</div>
                     </div>
                     <div class="input-group" id="lenc-group">
                       <label for="lenc">Lens Correction</label>
@@ -1571,11 +1571,11 @@
               </div>
               <div class="RCcontrolFmt RCsteerFmt">
                 <input title="Control RC steering" type="range" id="steerDirection" aria-label="Steer Direction" class="RCcontrol immed bigThumb ignore" value=0>
-                <div name="rangeVal" style="top: 2px" class="rvThumb">0</div>
+                <div name="rangeVal" style="top: 2px" class="rvThumb" aria-hidden="true">0</div>
               </div>
               <div class="RCcontrolFmt RCmotorFmt">
                 <input title="Control RC speed" type="range" id="motorSpeed" aria-label="Motor Speed" class="RCcontrol immed bigThumb ignore" value=0>
-                <div name="rangeVal" class="rvThumb">0</div>
+                <div name="rangeVal" class="rvThumb" aria-hidden="true">0</div>
               </div>
             </div>
             <img id="stream" src="" crossorigin alt="Live camera stream">
@@ -1761,7 +1761,7 @@
       <div id="buttonContainer">
         <!-- Input field for users to enter individual IPs -->
         <label for="ipInput">Enter IP address:&nbsp;</label>
-        <input type="text" id="ipInput" class="local" placeholder="e.g. 192.168.1.100" onkeydown="if(event.key === 'Enter') addIP()">
+        <input type="text" id="ipInput" class="local" autocorrect="off" autocapitalize="none" spellcheck="false" placeholder="e.g. 192.168.1.100" onkeydown="if(event.key === 'Enter') addIP()">
         <button id="addIpButton" class="local" onclick="addIP()" title="Add a new camera to the Hub" aria-label="Add entered IP address to Camera Hub">Add IP</button>
         <button id="clearStorageButton" class="local" onclick="clearLocalStorage()" title="Remove all saved cameras" aria-label="Delete all saved camera IP addresses">Delete All</button>
         <button id="refreshAllButton" class="local" onclick="refreshAllContainers(true)" title="Refresh all camera streams" aria-label="Refresh all camera images">Refresh</button>


### PR DESCRIPTION
💡 What: 
- Added `aria-hidden="true"` to visual bounds (`rangeMin`, `rangeMax`, `rangeVal`) of range sliders.
- Added `autocorrect="off"`, `autocapitalize="none"`, and `spellcheck="false"` to the `ipInput` text field.

🎯 Why: 
- Visual range slider bounds announce themselves redundantly to screen readers because the `<input type="range">` natively provides the same information. Hiding the visual bounds cleans up the a11y tree.
- Entering IP addresses on mobile keyboards often results in erroneous autocorrects or autocapitalizations, frustrating the user. Disabling these properties provides a much smoother UX.

📸 Before/After: 
Tested locally using Playwright (screenshots generated but not checked in).

♿ Accessibility: 
Improved screen reader experience by removing redundant announcements for range sliders. Improved mobile usability for configuration inputs.

---
*PR created automatically by Jules for task [3759597345114847327](https://jules.google.com/task/3759597345114847327) started by @ManupaKDU*