### PR TITLE
🎨 Palette: Disable autocorrect on dynamic text inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-01-29 - Mobile Input Redundancy
 **Learning:** Adding `autocorrect="off" autocapitalize="none" spellcheck="false"` to non-prose text inputs improves mobile accessibility.
 **Action:** Always add `autocorrect="off" autocapitalize="none" spellcheck="false"` to non-prose text inputs (like configurations or URLs).
+
+## 2025-02-18 - Disable autocorrect on dynamic configuration text inputs
+**Learning:** Text inputs dynamically generated in JavaScript (e.g. for configuration settings) must also disable autocorrect and autocapitalize to ensure users can enter precise configuration data without mobile keyboard interference.
+**Action:** When auditing or implementing mobile accessibility for configuration interfaces, remember to check not only static HTML but also JavaScript strings that generate input elements.

--- a/data/common.js
+++ b/data/common.js
@@ -901,10 +901,10 @@
                       inputHtml += '</select>';
                     break;
                     case 'T': // text input
-                      inputHtml = '<input type="text" class="configItem" id="' + saveKey + '" value="'+ saveVal +'" >';
+                      inputHtml = '<input type="text" class="configItem" id="' + saveKey + '" value="'+ saveVal +'" autocorrect="off" autocapitalize="none" spellcheck="false" >';
                     break;
                     case 'X': // text input field not updated by app
-                      inputHtml = '<input type="text" class="configItem nochange" id="' + saveKey + '" value="'+ saveVal +'" >';
+                      inputHtml = '<input type="text" class="configItem nochange" id="' + saveKey + '" value="'+ saveVal +'" autocorrect="off" autocapitalize="none" spellcheck="false" >';
                     break;
                     default:
                       alert("Unhandled config input type " + value);


### PR DESCRIPTION
💡 What: Added `autocorrect="off"`, `autocapitalize="none"`, and `spellcheck="false"` to the dynamically generated text inputs (types 'T' and 'X') in `data/common.js`.
🎯 Why: Mobile keyboards often interfere with configuration inputs (like hostnames or server addresses) by erroneously autocorrecting or capitalizing them, causing user frustration and invalid configuration data.
📸 Before/After: Not applicable as it is a behavioral change on mobile devices.
♿ Accessibility: Improves usability on mobile devices and aligns with mobile input best practices for configuration settings.

---
*PR created automatically by Jules for task [4730381885035607143](https://jules.google.com/task/4730381885035607143) started by @ManupaKDU*