### PR TITLE
⚡ Bolt: Optimize network buffer flushing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -127,3 +127,6 @@
 ## 2024-11-20 - Replace redundant strncpy+strlen with a single snprintf
 **Learning:** Using `strncpy` followed by `snprintf` with `strlen()` to append strings (e.g., `strncpy(subject, _subject, sizeof(subject)-1); snprintf(subject+strlen(subject), ...);`) causes redundant O(N) string traversals and creates potential buffer overruns.
 **Action:** Combine multi-step string building operations into a single bounded `snprintf(dest, sizeof(dest), "%s from %s", _subject, hostName)` to eliminate redundant string length calculations.
+## 2024-05-24 - Optimize network buffer flushing
+**Learning:** In ESP32/Arduino codebases, flushing network buffers with byte-by-byte reads (e.g., `while (client.available()) client.read();`) is inefficient and causes high network I/O latency and function call overhead.
+**Action:** Replace inefficient byte-by-byte reads with block reads using a local buffer (e.g., `uint8_t buf[64]; while (client.available()) client.read(buf, sizeof(buf));`) to reduce function call overhead and network I/O latency.

--- a/ftp.cpp
+++ b/ftp.cpp
@@ -152,7 +152,8 @@ static bool sendFtpCommand(const char* cmd, const char* param, const char* respC
   respCodeRx[3] = 0; // terminator
   int readLen = rclient.read((uint8_t*)rspBuf, 255);
   if (readLen >= 0) rspBuf[readLen] = 0;
-  while (rclient.available()) rclient.read(); // bin the rest of response
+  uint8_t flushBuf[64];
+  while (rclient.available()) rclient.read(flushBuf, sizeof(flushBuf)); // bin the rest of response
 
   // check response code with expected
   LOG_VRB("Rx code: %s, resp: %s", respCodeRx, rspBuf);

--- a/smtp.cpp
+++ b/smtp.cpp
@@ -57,7 +57,8 @@ static bool sendSmtpCommand(NetworkClientSecure& client, const char* cmd, const 
   respCodeRx[3] = 0; // terminator
   int readLen = client.read((uint8_t*)rspBuf, 255);
   rspBuf[readLen] = 0;
-  while (client.available()) client.read(); // bin the rest of response
+  uint8_t flushBuf[64];
+  while (client.available()) client.read(flushBuf, sizeof(flushBuf)); // bin the rest of response
 
   // check response code with expected
   LOG_VRB("Rx code: %s, resp: %s", respCodeRx, rspBuf);

--- a/utils.cpp
+++ b/utils.cpp
@@ -568,7 +568,8 @@ static uint8_t failCounts[REMFAILCNT] = {0};
 
 void remoteServerClose(Client& client) {
   uint32_t startAttempt = millis();
-  while (client.available() > 0 && (millis() - startAttempt < 1000)) client.read();
+  uint8_t flushBuf[64];
+  while (client.available() > 0 && (millis() - startAttempt < 1000)) client.read(flushBuf, sizeof(flushBuf));
   if (client.connected()) client.stop();
 }
 


### PR DESCRIPTION
💡 What: Replaced byte-by-byte `client.read()` calls with block reads into a 64-byte local buffer when flushing remaining network responses in `ftp.cpp`, `smtp.cpp`, and `utils.cpp`.
🎯 Why: Calling `client.read()` one byte at a time introduces significant function call overhead and network I/O latency.
📊 Impact: Reduces CPU cycles and time spent waiting for network I/O during buffer flushing, speeding up network cleanup operations.
🔬 Measurement: Network operations like FTP and SMTP will conclude faster, and CPU time spent in `remoteServerClose` will decrease. This can be verified by measuring the execution time of these flushing loops.

---
*PR created automatically by Jules for task [4395789910990137856](https://jules.google.com/task/4395789910990137856) started by @ManupaKDU*