### PR TITLE
⚡ Bolt: Optimize network buffer flushing

### DIFF
--- a/ftp.cpp
+++ b/ftp.cpp
@@ -152,7 +152,8 @@ static bool sendFtpCommand(const char* cmd, const char* param, const char* respC
   respCodeRx[3] = 0; // terminator
   int readLen = rclient.read((uint8_t*)rspBuf, 255);
   if (readLen >= 0) rspBuf[readLen] = 0;
-  while (rclient.available()) rclient.read(); // bin the rest of response
+  uint8_t flushBuf[64];
+  while (rclient.available()) rclient.read(flushBuf, sizeof(flushBuf)); // bin the rest of response
 
   // check response code with expected
   LOG_VRB("Rx code: %s, resp: %s", respCodeRx, rspBuf);

--- a/smtp.cpp
+++ b/smtp.cpp
@@ -57,7 +57,8 @@ static bool sendSmtpCommand(NetworkClientSecure& client, const char* cmd, const 
   respCodeRx[3] = 0; // terminator
   int readLen = client.read((uint8_t*)rspBuf, 255);
   rspBuf[readLen] = 0;
-  while (client.available()) client.read(); // bin the rest of response
+  uint8_t flushBuf[64];
+  while (client.available()) client.read(flushBuf, sizeof(flushBuf)); // bin the rest of response
 
   // check response code with expected
   LOG_VRB("Rx code: %s, resp: %s", respCodeRx, rspBuf);

--- a/utils.cpp
+++ b/utils.cpp
@@ -568,7 +568,8 @@ static uint8_t failCounts[REMFAILCNT] = {0};
 
 void remoteServerClose(Client& client) {
   uint32_t startAttempt = millis();
-  while (client.available() > 0 && (millis() - startAttempt < 1000)) client.read();
+  uint8_t flushBuf[64];
+  while (client.available() > 0 && (millis() - startAttempt < 1000)) client.read(flushBuf, sizeof(flushBuf));
   if (client.connected()) client.stop();
 }
 


### PR DESCRIPTION
💡 What: Replaced byte-by-byte `client.read()` calls in `smtp.cpp`, `ftp.cpp`, and `utils.cpp` loops with block reads (`client.read(flushBuf, sizeof(flushBuf))`).
🎯 Why: To reduce function call overhead and bypass the Arduino/ESP32 framework's per-byte `timedRead()` timeouts when draining unneeded response bytes, significantly improving performance.
📊 Impact: Substantially reduces CPU time wasted on I/O overhead and latency when waiting for or discarding server responses.
🔬 Measurement: Observe faster connection teardowns and less time spent blocking in network operations (e.g., SMTP and FTP communication).

---
*PR created automatically by Jules for task [10032590830483273513](https://jules.google.com/task/10032590830483273513) started by @ManupaKDU*