### PR TITLE
🎨 Palette: Improve Mobile Accessibility for Inputs and Sliders

### DIFF
--- a/data/Auxil.htm
+++ b/data/Auxil.htm
@@ -928,7 +928,7 @@
                     <label for="fsUse">Upload method:</label>FTP&nbsp;
                     <div class="switch">
                       <input id="fsUse" type="checkbox">
-                      <label title="Upload file using FTP or HFS" class="slider" for="fsUse"></label>
+                      <label title="Upload file using FTP or HFS" class="slider" for="fsUse" aria-hidden="true"></label>
                     </div>&nbsp;HFS
                   </div>
                   <br>
@@ -973,14 +973,14 @@
                     <label for="useHttps">Use HTTPS</label>
                     <div class="switch">
                       <input id="useHttps" type="checkbox">
-                      <label title="Use HTTPS to access app" class="slider" for="useHttps"></label>
+                      <label title="Use HTTPS to access app" class="slider" for="useHttps" aria-hidden="true"></label>
                     </div>
                   </div>
                   <div class="input-group" id="auth-group">
                     <label for="useSecure">Check Certs</label>
                     <div class="switch">
                       <input id="useSecure" type="checkbox">
-                      <label title="Check remote servers certificate" class="slider" for="useSecure"></label>
+                      <label title="Check remote servers certificate" class="slider" for="useSecure" aria-hidden="true"></label>
                     </div>
                   </div>
                 </div>
@@ -1053,7 +1053,7 @@
         <div class="input-group" id="dbg-group" style="text-align: right">
           <div class="switch">
             <input id="dbgVerbose" type="checkbox">
-            <label title="Outputs additional information to log" class="slider" for="dbgVerbose"></label>
+            <label title="Outputs additional information to log" class="slider" for="dbgVerbose" aria-hidden="true"></label>
           </div>
         </div>
         <br>

--- a/data/common.js
+++ b/data/common.js
@@ -872,13 +872,13 @@
                       // format checkbox as slider
                       inputHtml = '<div class="switch"><input type="checkbox" class="configItem" id="' + saveKey;
                       inputHtml += '" value="'+ saveVal +'"' + (saveVal == 1 ? ' checked' : '') + '>';
-                      inputHtml += '<label class="slider" title="Toggle ' + saveKey + '" for="' + saveKey + '"></label></div>';
+                      inputHtml += '<label class="slider" title="Toggle ' + saveKey + '" for="' + saveKey + '" aria-hidden="true"></label></div>';
                     break;
                     case 'D': // display only
-                      inputHtml = '<input type="text" class="configItem" id="' + saveKey + '" value="'+ saveVal +'" readonly style="background-color: var(--menuBackground);">';
+                      inputHtml = '<input type="text" class="configItem" id="' + saveKey + '" value="'+ saveVal +'" readonly style="background-color: var(--menuBackground);" autocorrect="off" autocapitalize="none" spellcheck="false">';
                     break;
                     case 'L': // binary string input
-                      inputHtml = `<input type="text" oninput="this.value = this.value.replace(/[^01]/g, '')" placeholder="0101..." class="configItem" id="` + saveKey + `" value="`+ saveVal +`" >`;
+                      inputHtml = `<input type="text" oninput="this.value = this.value.replace(/[^01]/g, '')" placeholder="0101..." class="configItem" id="` + saveKey + `" value="`+ saveVal +`"  autocorrect="off" autocapitalize="none" spellcheck="false">`;
                     break;
                     case 'N': // number input
                       inputHtml = '<input type="number" class="configItem" id="' + saveKey + '" value="'+ saveVal +'" >';
@@ -901,10 +901,10 @@
                       inputHtml += '</select>';
                     break;
                     case 'T': // text input
-                      inputHtml = '<input type="text" class="configItem" id="' + saveKey + '" value="'+ saveVal +'" >';
+                      inputHtml = '<input type="text" class="configItem" id="' + saveKey + '" value="'+ saveVal +'"  autocorrect="off" autocapitalize="none" spellcheck="false">';
                     break;
                     case 'X': // text input field not updated by app
-                      inputHtml = '<input type="text" class="configItem nochange" id="' + saveKey + '" value="'+ saveVal +'" >';
+                      inputHtml = '<input type="text" class="configItem nochange" id="' + saveKey + '" value="'+ saveVal +'"  autocorrect="off" autocapitalize="none" spellcheck="false">';
                     break;
                     default:
                       alert("Unhandled config input type " + value);


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to visual labels for range sliders and added `autocorrect="off" autocapitalize="none" spellcheck="false"` to text configuration inputs in `data/Auxil.htm` and dynamically generated inputs in `data/common.js`.
🎯 Why: Range sliders natively announce their values to screen readers, making the visual label redundant and confusing. Disabling autocorrect and autocapitalization prevents mobile keyboards from improperly modifying configuration settings like hostnames.
📸 Before/After: Visual changes are not visible; improvements are for screen readers and mobile keyboards.
♿ Accessibility: Reduces redundant screen reader announcements and improves mobile input reliability for configuration forms.

---
*PR created automatically by Jules for task [9197445084263671493](https://jules.google.com/task/9197445084263671493) started by @ManupaKDU*