### PR TITLE
⚡ Bolt: Optimize network buffer flushing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -127,3 +127,6 @@
 ## 2024-11-20 - Replace redundant strncpy+strlen with a single snprintf
 **Learning:** Using `strncpy` followed by `snprintf` with `strlen()` to append strings (e.g., `strncpy(subject, _subject, sizeof(subject)-1); snprintf(subject+strlen(subject), ...);`) causes redundant O(N) string traversals and creates potential buffer overruns.
 **Action:** Combine multi-step string building operations into a single bounded `snprintf(dest, sizeof(dest), "%s from %s", _subject, hostName)` to eliminate redundant string length calculations.
+## 2024-05-29 - Block reads for network buffer flushing
+**Learning:** In ESP32/Arduino codebases, clearing network buffers byte-by-byte via `client.read()` inside a `while (client.available())` loop introduces significant O(N) function call overhead and latency.
+**Action:** Replace byte-by-byte reads with bulk block reads using a local stack buffer (e.g., `uint8_t buf[64]; while (client.available()) client.read(buf, sizeof(buf));`) to flush data more efficiently.

--- a/ftp.cpp
+++ b/ftp.cpp
@@ -152,7 +152,7 @@ static bool sendFtpCommand(const char* cmd, const char* param, const char* respC
   respCodeRx[3] = 0; // terminator
   int readLen = rclient.read((uint8_t*)rspBuf, 255);
   if (readLen >= 0) rspBuf[readLen] = 0;
-  while (rclient.available()) rclient.read(); // bin the rest of response
+  { uint8_t buf[64]; while (rclient.available()) rclient.read(buf, sizeof(buf)); } // bin the rest of response
 
   // check response code with expected
   LOG_VRB("Rx code: %s, resp: %s", respCodeRx, rspBuf);

--- a/smtp.cpp
+++ b/smtp.cpp
@@ -57,7 +57,7 @@ static bool sendSmtpCommand(NetworkClientSecure& client, const char* cmd, const 
   respCodeRx[3] = 0; // terminator
   int readLen = client.read((uint8_t*)rspBuf, 255);
   rspBuf[readLen] = 0;
-  while (client.available()) client.read(); // bin the rest of response
+  { uint8_t buf[64]; while (client.available()) client.read(buf, sizeof(buf)); } // bin the rest of response
 
   // check response code with expected
   LOG_VRB("Rx code: %s, resp: %s", respCodeRx, rspBuf);

--- a/utils.cpp
+++ b/utils.cpp
@@ -568,7 +568,7 @@ static uint8_t failCounts[REMFAILCNT] = {0};
 
 void remoteServerClose(Client& client) {
   uint32_t startAttempt = millis();
-  while (client.available() > 0 && (millis() - startAttempt < 1000)) client.read();
+  { uint8_t buf[64]; while (client.available() > 0 && (millis() - startAttempt < 1000)) client.read(buf, sizeof(buf)); }
   if (client.connected()) client.stop();
 }
 


### PR DESCRIPTION
- 💡 What: Replaced byte-by-byte network buffer flushing via `while(client.available()) client.read();` with 64-byte block reads using a local stack buffer (`uint8_t buf[64]`) in `utils.cpp`, `ftp.cpp`, and `smtp.cpp`.
- 🎯 Why: Reading byte-by-byte invokes a virtual function call and internal state checks for every single byte. When simply discarding remaining data in a buffer to close a connection cleanly, this introduces massive unnecessary overhead.
- 📊 Impact: Substantially faster connection tear-down and response skipping, saving valuable CPU cycles and reducing blocking time on network operations without using additional heap memory.
- 🔬 Measurement: Observe overall network task responsiveness and measure execution time of `remoteServerClose` or SMTP/FTP response parsing routines.

---
*PR created automatically by Jules for task [12176504076868483440](https://jules.google.com/task/12176504076868483440) started by @ManupaKDU*