### PR TITLE
🧹 Refactor sprintf to snprintf in utilsLog.cpp

### DIFF
--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -549,22 +549,42 @@ static void printGpioInfo() {
     if (type == ESP32_BUS_TYPE_INIT) continue;  //unused pin
 
     char gpioInf[100];
+    size_t rem = sizeof(gpioInf);
     char* p = gpioInf;
+    int written;
+
 #if defined(BOARD_HAS_PIN_REMAP)
     int dpin = gpioNumberToDigitalPin(i);
     if (dpin < 0) continue;  //pin is not exported
-    else p+= sprintf(p, "  D%-3d|%4u : ", dpin, i);
+    else {
+      written = snprintf(p, rem, "  D%-3d|%4u : ", dpin, i);
+      if (written > 0 && written < (int)rem) { p += written; rem -= written; }
+    }
 #else
-    p+= sprintf(p, "  %4u : ", i);
+    written = snprintf(p, rem, "  %4u : ", i);
+    if (written > 0 && written < (int)rem) { p += written; rem -= written; }
 #endif
+
     const char *extra_type = perimanGetPinBusExtraType(i);
-    if (extra_type) p+= sprintf(p, "%s", extra_type);
-    else p+= sprintf(p, "%s", perimanGetTypeName(type));
+    if (extra_type) {
+      written = snprintf(p, rem, "%s", extra_type);
+      if (written > 0 && written < (int)rem) { p += written; rem -= written; }
+    } else {
+      written = snprintf(p, rem, "%s", perimanGetTypeName(type));
+      if (written > 0 && written < (int)rem) { p += written; rem -= written; }
+    }
+
     int8_t bus_number = perimanGetPinBusNum(i);
-    if (bus_number != -1) p+= sprintf(p, "[%u]", bus_number);
+    if (bus_number != -1) {
+      written = snprintf(p, rem, "[%u]", bus_number);
+      if (written > 0 && written < (int)rem) { p += written; rem -= written; }
+    }
 
     int8_t bus_channel = perimanGetPinBusChannel(i);
-    if (bus_channel != -1) p+= sprintf(p, "[%u]", bus_channel);
+    if (bus_channel != -1) {
+      written = snprintf(p, rem, "[%u]", bus_channel);
+      if (written > 0 && written < (int)rem) { p += written; rem -= written; }
+    }
     *p = 0;
     LOG_SEND("%s\n", gpioInf);
   }


### PR DESCRIPTION
🎯 **What:** Replaced unsafe `sprintf()` calls with `snprintf()` in the `printGpioInfo` function in `utilsLog.cpp`.

💡 **Why:** To improve codebase safety and maintainability. `sprintf()` does not check bounds and can lead to buffer overflows if the formatted string exceeds the buffer size. By using `snprintf()` and tracking the remaining buffer size (`rem`), we ensure that formatting never writes past the allocated memory.

✅ **Verification:** 
- Reviewed the modifications with `git diff`.
- Compiled and ran the relevant test file `tests/test_utilsLog.cpp` locally. Tests passed successfully.
- Code review verified that the implementation correctly bounds the string writes and handles the pointer/size updates safely.

✨ **Result:** A safer, more robust string formatting implementation that protects against potential buffer overflows without changing existing functionality.

---
*PR created automatically by Jules for task [773639216866416896](https://jules.google.com/task/773639216866416896) started by @ManupaKDU*