### PR TITLE
🧹 Replace strcpy with strncpy to prevent buffer overflows

### DIFF
--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -227,7 +227,10 @@ static void appPanicHandler(arduino_panic_info_t *info, void *arg) {
 }
 
 static void expandReason() {
-  if (!btReason[0]) strcpy(btReason, "unknown");
+  if (!btReason[0]) {
+    strncpy(btReason, "unknown", sizeof(btReason) - 1);
+    btReason[sizeof(btReason) - 1] = '\0';
+  }
 #if CONFIG_IDF_TARGET_ARCH_RISCV
   // riscV
   else if (strstr(btReason, "Breakpoint") != NULL) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()


### PR DESCRIPTION
🎯 **What:** Replaced the unsafe `strcpy` with `strncpy` in `utilsLog.cpp` to populate `btReason`.
💡 **Why:** `strncpy` prevents potential buffer overflows by restricting the copy length to the available buffer size, improving code health and safety.
✅ **Verification:** Verified the code using `git diff` to confirm logical preservation. Confirmed the test executable `test_utilsLog` compiled and executed successfully.
✨ **Result:** Improved the safety of the `expandReason` function and removed potential vulnerabilities.

---
*PR created automatically by Jules for task [18310041557627222145](https://jules.google.com/task/18310041557627222145) started by @ManupaKDU*