### PR TITLE
🧹 Refactor streamServer.cpp to use safer snprintf

### DIFF
--- a/streamServer.cpp
+++ b/streamServer.cpp
@@ -208,12 +208,17 @@ static void srtStream(httpd_req_t* req, uint8_t taskNum) {
     srtSeqNo++;
     uint32_t startTime = millis();
     formatElapsedTime(timeStr, srtTime, true);
-    size_t srtPtr = sprintf(srtHdr, "%d\n%s --> ", srtSeqNo, timeStr);
+    size_t srtPtr = 0;
+    int written = snprintf(srtHdr, sizeof(srtHdr), "%d\n%s --> ", srtSeqNo, timeStr);
+    if (written > 0 && written < sizeof(srtHdr)) srtPtr += written;
     srtTime += sampleInterval;
     formatElapsedTime(timeStr, srtTime, true);
-    srtPtr += sprintf(srtHdr + srtPtr, "%s\n", timeStr);
+    written = snprintf(srtHdr + srtPtr, sizeof(srtHdr) - srtPtr, "%s\n", timeStr);
+    if (written > 0 && written < sizeof(srtHdr) - srtPtr) srtPtr += written;
     time_t currEpoch = getEpoch();
-    srtPtr += strftime(srtHdr + srtPtr, 12, "%H:%M:%S  ", localtime(&currEpoch));
+    if (srtPtr < sizeof(srtHdr)) {
+      srtPtr += strftime(srtHdr + srtPtr, sizeof(srtHdr) - srtPtr, "%H:%M:%S  ", localtime(&currEpoch));
+    }
     httpd_resp_send_chunk(req, (const char*)srtHdr, srtPtr);
 #if INCLUDE_TELEM
     // add telemetry data 


### PR DESCRIPTION
🎯 **What:** Replaced unsafe `sprintf` calls with bounds-checked `snprintf` in `srtStream` function of `streamServer.cpp`.
💡 **Why:** To prevent potential buffer overflows when formatting data into the `srtHdr` array, improving the code's robustness and maintainability.
✅ **Verification:** Verified that the replacement code correctly bounds-checks the string construction and ran tests to confirm functionality remains intact.
✨ **Result:** Improved code safety by mitigating memory corruption vectors without changing existing functionality.

---
*PR created automatically by Jules for task [5951831487874181063](https://jules.google.com/task/5951831487874181063) started by @ManupaKDU*