### PR TITLE
🧹 Refactor: Replace sprintf with snprintf in utilsLog.cpp

### DIFF
--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -230,15 +230,15 @@ static void expandReason() {
   if (!btReason[0]) strcpy(btReason, "unknown");
 #if CONFIG_IDF_TARGET_ARCH_RISCV
   // riscV
-  else if (strstr(btReason, "Breakpoint") != NULL) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-  else if (strstr(btReason, "Stack protection fault") != NULL) sprintf(btReason, "stack overflow after HWM: %lu bytes", btHWM);  
+  else if (strstr(btReason, "Breakpoint") != NULL) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+  else if (strstr(btReason, "Stack protection fault") != NULL) snprintf(btReason, sizeof(btReason), "stack overflow after HWM: %lu bytes", btHWM);
   else if (!strcmp(btReason, "LoadAccessFault") || !strcmp(btReason, "StoreAccessFault") || !strcmp(btReason, "InstructionAccessFault")) strcat(btReason, " (pointer issue)");
 #else
   // Xtensa
   else if (strstr(btReason, "Unhandled debug exception") != NULL) {
-    if (btHWM < HWM_MIN) sprintf(btReason, "probably stack overflow @ HWM: %lu bytes", btHWM);
-    else if (btHWM > HWM_MAX) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-    else sprintf(btReason, "stack overflow / printf format. HWM: %lu bytes", btHWM); 
+    if (btHWM < HWM_MIN) snprintf(btReason, sizeof(btReason), "probably stack overflow @ HWM: %lu bytes", btHWM);
+    else if (btHWM > HWM_MAX) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+    else snprintf(btReason, sizeof(btReason), "stack overflow / printf format. HWM: %lu bytes", btHWM);
   }
   else if (!strcmp(btReason, "LoadProhibited") || !strcmp(btReason, "StoreProhibited") || !strcmp(btReason, "InstructionFetchError")) strcat(btReason, " (pointer issue)");
 #endif
@@ -368,7 +368,7 @@ static void boardInfo() {
 #endif
   char memInfo[100] = "none";
 #if !CONFIG_IDF_TARGET_ESP32C3
-  if (psramFound()) sprintf(memInfo, "%s, mode %s @ %dMhz", fmtSize(ESP.getPsramSize()), psramMode, CONFIG_SPIRAM_SPEED);
+  if (psramFound()) snprintf(memInfo, sizeof(memInfo), "%s, mode %s @ %dMhz", fmtSize(ESP.getPsramSize()), psramMode, CONFIG_SPIRAM_SPEED);
 #endif
   LOG_INF("PSRAM %s", memInfo);
 }
@@ -549,23 +549,39 @@ static void printGpioInfo() {
     if (type == ESP32_BUS_TYPE_INIT) continue;  //unused pin
 
     char gpioInf[100];
-    char* p = gpioInf;
+    size_t len = 0;
+    int written = 0;
 #if defined(BOARD_HAS_PIN_REMAP)
     int dpin = gpioNumberToDigitalPin(i);
     if (dpin < 0) continue;  //pin is not exported
-    else p+= sprintf(p, "  D%-3d|%4u : ", dpin, i);
+    else {
+      written = snprintf(gpioInf + len, sizeof(gpioInf) - len, "  D%-3d|%4u : ", dpin, i);
+      if (written > 0 && written < sizeof(gpioInf) - len) len += written;
+    }
 #else
-    p+= sprintf(p, "  %4u : ", i);
+    written = snprintf(gpioInf + len, sizeof(gpioInf) - len, "  %4u : ", i);
+    if (written > 0 && written < sizeof(gpioInf) - len) len += written;
 #endif
     const char *extra_type = perimanGetPinBusExtraType(i);
-    if (extra_type) p+= sprintf(p, "%s", extra_type);
-    else p+= sprintf(p, "%s", perimanGetTypeName(type));
+    if (extra_type) {
+      written = snprintf(gpioInf + len, sizeof(gpioInf) - len, "%s", extra_type);
+      if (written > 0 && written < sizeof(gpioInf) - len) len += written;
+    } else {
+      written = snprintf(gpioInf + len, sizeof(gpioInf) - len, "%s", perimanGetTypeName(type));
+      if (written > 0 && written < sizeof(gpioInf) - len) len += written;
+    }
     int8_t bus_number = perimanGetPinBusNum(i);
-    if (bus_number != -1) p+= sprintf(p, "[%u]", bus_number);
+    if (bus_number != -1) {
+      written = snprintf(gpioInf + len, sizeof(gpioInf) - len, "[%u]", bus_number);
+      if (written > 0 && written < sizeof(gpioInf) - len) len += written;
+    }
 
     int8_t bus_channel = perimanGetPinBusChannel(i);
-    if (bus_channel != -1) p+= sprintf(p, "[%u]", bus_channel);
-    *p = 0;
+    if (bus_channel != -1) {
+      written = snprintf(gpioInf + len, sizeof(gpioInf) - len, "[%u]", bus_channel);
+      if (written > 0 && written < sizeof(gpioInf) - len) len += written;
+    }
+    gpioInf[len] = '\0';
     LOG_SEND("%s\n", gpioInf);
   }
 }


### PR DESCRIPTION
🎯 **What:** Replace `sprintf` calls with safer `snprintf` in `utilsLog.cpp`.
💡 **Why:** To improve codebase health by replacing unsafe `sprintf` calls with safer alternatives like `snprintf` to prevent potential buffer overflows, and improving maintainability and readability.
✅ **Verification:** Modified the code and successfully compiled and ran the local C++ test suite `test_utilsLog` to ensure tests passed.
✨ **Result:** Improved maintainability by using memory-safe string formatting alternatives across the codebase, successfully reducing buffer overflow risks without changing behavior.

---
*PR created automatically by Jules for task [19543223330787332](https://jules.google.com/task/19543223330787332) started by @ManupaKDU*