### PR TITLE
🧪 Add tests for formatHex utility

### DIFF
--- a/tests/test_utilsLog.cpp
+++ b/tests/test_utilsLog.cpp
@@ -21,6 +21,21 @@
 #define ESP_PARTITION_SUBTYPE_DATA_FAT 0x81
 
 #define TEST_ENV
+
+#include <cstdarg>
+
+// Mock logging macro for testing formatHex
+char lastLog[1024] = {0};
+
+void mock_log(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(lastLog, sizeof(lastLog), fmt, args);
+    va_end(args);
+    // std::cout << "MOCK LOG: " << lastLog << std::endl;
+}
+#define LOG_INF(...) mock_log(__VA_ARGS__)
+
 #include "../utilsLog.cpp"
 
 void test_partitionTypeToStr() {
@@ -31,7 +46,34 @@ void test_partitionTypeToStr() {
     std::cout << "All partitionTypeToStr tests passed!" << std::endl;
 }
 
+
+void formatHex(const char* inData, size_t inLen);
+void test_formatHex() {
+    // Test 1: Typical byte array
+    const char data1[] = {(char)0xDE, (char)0xAD, (char)0xBE, (char)0xEF};
+    formatHex(data1, sizeof(data1));
+    assert(strcmp(lastLog, "Hex: de ad be ef ") == 0);
+
+    // Test 2: Single byte
+    const char data2[] = {0x00};
+    formatHex(data2, sizeof(data2));
+    assert(strcmp(lastLog, "Hex: 00 ") == 0);
+
+    // Test 3: Empty data
+    lastLog[0] = '\0'; // Reset log
+    formatHex(nullptr, 0);
+    assert(strcmp(lastLog, "Hex: ") == 0);
+
+    // Test 4: Extended bytes that might cause sign extension if not handled properly
+    const char data4[] = {0x7F, (char)0x80, (char)0xFF};
+    formatHex(data4, sizeof(data4));
+    assert(strcmp(lastLog, "Hex: 7f 80 ff ") == 0);
+
+    std::cout << "All formatHex tests passed!" << std::endl;
+}
+
 int main() {
+    test_formatHex();
     test_partitionTypeToStr();
     return 0;
 }

--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -195,13 +195,6 @@ int vprintfRedirect(const char* format, va_list args) {
 }
 
 
-void formatHex(const char* inData, size_t inLen) {
-  // format data as hex bytes for output
-  char formatted[(inLen * 3) + 1];
-  for (int i=0; i<inLen; i++) snprintf(formatted + (i*3), 4, "%02x ", (unsigned char)inData[i]);
-  formatted[(inLen * 3)] = 0; // terminator
-  LOG_INF("Hex: %s", formatted);
-}
 
 const char* espErrMsg(esp_err_t errCode) {
   // convert esp error code to text
@@ -571,6 +564,16 @@ static void printGpioInfo() {
 }
 
 #endif // TEST_ENV
+void formatHex(const char* inData, size_t inLen) {
+  // format data as hex bytes for output
+  char formatted[(inLen * 3) + 1];
+  for (int i=0; i<inLen; i++) snprintf(formatted + (i*3), 4, "%02x ", (unsigned char)inData[i]);
+  formatted[(inLen * 3)] = 0; // terminator
+  LOG_INF("Hex: %s", formatted);
+}
+
+
+
 // display partition map
 const char* partitionTypeToStr(uint8_t type) {
   // Map type to string


### PR DESCRIPTION
🎯 **What:** Moved `formatHex` outside the `#ifndef TEST_ENV` block in `utilsLog.cpp` to make it testable and implemented a mock-based test suite in `tests/test_utilsLog.cpp`.
📊 **Coverage:** Added coverage for typical byte arrays, single bytes, empty data, and extended bytes with high bits set to verify against sign extension.
✨ **Result:** Increased test coverage and confidence in the formatting utility used for diagnostic hex output, preventing potential regression bugs.

---
*PR created automatically by Jules for task [12914918926791409284](https://jules.google.com/task/12914918926791409284) started by @ManupaKDU*