### PR TITLE
🧹 Code Health: Replace unsafe sprintf with snprintf in utilsLog.cpp

### DIFF
--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -230,17 +230,17 @@ static void expandReason() {
   if (!btReason[0]) strcpy(btReason, "unknown");
 #if CONFIG_IDF_TARGET_ARCH_RISCV
   // riscV
-  else if (strstr(btReason, "Breakpoint") != NULL) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-  else if (strstr(btReason, "Stack protection fault") != NULL) sprintf(btReason, "stack overflow after HWM: %lu bytes", btHWM);  
-  else if (!strcmp(btReason, "LoadAccessFault") || !strcmp(btReason, "StoreAccessFault") || !strcmp(btReason, "InstructionAccessFault")) strcat(btReason, " (pointer issue)");
+  else if (strstr(btReason, "Breakpoint") != NULL) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+  else if (strstr(btReason, "Stack protection fault") != NULL) snprintf(btReason, sizeof(btReason), "stack overflow after HWM: %lu bytes", btHWM);
+  else if (!strcmp(btReason, "LoadAccessFault") || !strcmp(btReason, "StoreAccessFault") || !strcmp(btReason, "InstructionAccessFault")) strncat(btReason, " (pointer issue)", sizeof(btReason) - strlen(btReason) - 1);
 #else
   // Xtensa
   else if (strstr(btReason, "Unhandled debug exception") != NULL) {
-    if (btHWM < HWM_MIN) sprintf(btReason, "probably stack overflow @ HWM: %lu bytes", btHWM);
-    else if (btHWM > HWM_MAX) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-    else sprintf(btReason, "stack overflow / printf format. HWM: %lu bytes", btHWM); 
+    if (btHWM < HWM_MIN) snprintf(btReason, sizeof(btReason), "probably stack overflow @ HWM: %lu bytes", btHWM);
+    else if (btHWM > HWM_MAX) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+    else snprintf(btReason, sizeof(btReason), "stack overflow / printf format. HWM: %lu bytes", btHWM);
   }
-  else if (!strcmp(btReason, "LoadProhibited") || !strcmp(btReason, "StoreProhibited") || !strcmp(btReason, "InstructionFetchError")) strcat(btReason, " (pointer issue)");
+  else if (!strcmp(btReason, "LoadProhibited") || !strcmp(btReason, "StoreProhibited") || !strcmp(btReason, "InstructionFetchError")) strncat(btReason, " (pointer issue)", sizeof(btReason) - strlen(btReason) - 1);
 #endif
 }
 
@@ -368,7 +368,7 @@ static void boardInfo() {
 #endif
   char memInfo[100] = "none";
 #if !CONFIG_IDF_TARGET_ESP32C3
-  if (psramFound()) sprintf(memInfo, "%s, mode %s @ %dMhz", fmtSize(ESP.getPsramSize()), psramMode, CONFIG_SPIRAM_SPEED);
+  if (psramFound()) snprintf(memInfo, 100, "%s, mode %s @ %dMhz", fmtSize(ESP.getPsramSize()), psramMode, CONFIG_SPIRAM_SPEED);
 #endif
   LOG_INF("PSRAM %s", memInfo);
 }
@@ -553,18 +553,36 @@ static void printGpioInfo() {
 #if defined(BOARD_HAS_PIN_REMAP)
     int dpin = gpioNumberToDigitalPin(i);
     if (dpin < 0) continue;  //pin is not exported
-    else p+= sprintf(p, "  D%-3d|%4u : ", dpin, i);
+    else {
+      int w = snprintf(p, gpioInf + sizeof(gpioInf) - p, "  D%-3d|%4u : ", dpin, i);
+      if (w > 0 && w < gpioInf + sizeof(gpioInf) - p) p += w;
+    }
 #else
-    p+= sprintf(p, "  %4u : ", i);
+    {
+      int w = snprintf(p, gpioInf + sizeof(gpioInf) - p, "  %4u : ", i);
+      if (w > 0 && w < gpioInf + sizeof(gpioInf) - p) p += w;
+    }
 #endif
     const char *extra_type = perimanGetPinBusExtraType(i);
-    if (extra_type) p+= sprintf(p, "%s", extra_type);
-    else p+= sprintf(p, "%s", perimanGetTypeName(type));
+    if (extra_type) {
+      int w = snprintf(p, gpioInf + sizeof(gpioInf) - p, "%s", extra_type);
+      if (w > 0 && w < gpioInf + sizeof(gpioInf) - p) p += w;
+    }
+    else {
+      int w = snprintf(p, gpioInf + sizeof(gpioInf) - p, "%s", perimanGetTypeName(type));
+      if (w > 0 && w < gpioInf + sizeof(gpioInf) - p) p += w;
+    }
     int8_t bus_number = perimanGetPinBusNum(i);
-    if (bus_number != -1) p+= sprintf(p, "[%u]", bus_number);
+    if (bus_number != -1) {
+      int w = snprintf(p, gpioInf + sizeof(gpioInf) - p, "[%u]", bus_number);
+      if (w > 0 && w < gpioInf + sizeof(gpioInf) - p) p += w;
+    }
 
     int8_t bus_channel = perimanGetPinBusChannel(i);
-    if (bus_channel != -1) p+= sprintf(p, "[%u]", bus_channel);
+    if (bus_channel != -1) {
+      int w = snprintf(p, gpioInf + sizeof(gpioInf) - p, "[%u]", bus_channel);
+      if (w > 0 && w < gpioInf + sizeof(gpioInf) - p) p += w;
+    }
     *p = 0;
     LOG_SEND("%s\n", gpioInf);
   }


### PR DESCRIPTION
🎯 **What:** Replaced unsafe `sprintf` and `strcat` with bounds-checked `snprintf` and `strncat` functions in `utilsLog.cpp`. Updated chaining calls in `printGpioInfo` to correctly accumulate buffer lengths without out-of-bounds writes on truncation.
💡 **Why:** This improves the safety and code health of the project. Replacing `sprintf` with safer alternatives like `snprintf` explicitly prevents potential buffer overflows during string manipulation.
✅ **Verification:** Ran `g++ -o test_utilsLog tests/test_utilsLog.cpp && ./test_utilsLog` to ensure the compilation and behavior remained correct. Verified changes with `git diff`. Passed automated code review.
✨ **Result:** Improved memory safety in logging and setup functions.

---
*PR created automatically by Jules for task [6692324785355000778](https://jules.google.com/task/6692324785355000778) started by @ManupaKDU*