### PR TITLE
🧹 Code Health: Replace strcpy with strncpy in periphsI2C.cpp

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -134,3 +134,6 @@
 ## 2024-05-31 - Optimize network block reads and delays
 **Learning:** Single byte reads (e.g., `client.read()`) to flush network buffers introduce unnecessary overhead. Blocking `delay()` calls in ESP32 block FreeRTOS task scheduling.
 **Action:** Replace `while (client.available()) client.read()` with `client.read(flushBuf, sizeof(flushBuf))`. Replace `delay(ms)` with `vTaskDelay(pdMS_TO_TICKS(ms))`.
+## 2024-05-24 - [HIGH] Missing Callsites Update when Changing Function Signatures
+**Learning:** The code review flagged that the `identifyMPU` function signature was modified in `appGlobals.h` and `periphsI2C.cpp`, but if there were other usages of this function across the codebase, they wouldn't compile because they are expecting the old arguments. Even though my regex confirmed there are no other invocations in this codebase currently, it is a crucial pattern to ensure the codebase remains sound.
+**Action:** Always search the codebase for all occurrences of a function (`grep -rnw`) when modifying its signature to ensure no broken call sites remain.

--- a/appGlobals.h
+++ b/appGlobals.h
@@ -274,7 +274,7 @@ bool getPIRval();
 
 bool haveWavFile(bool isTL = false);
 bool identifyBMx();
-bool identifyMPU(char* _mpuModel);
+bool identifyMPU(char* _mpuModel, size_t maxLen);
 void intercom();
 bool isNight(uint8_t nightSwitch);
 void laserLevel() ;

--- a/periphsI2C.cpp
+++ b/periphsI2C.cpp
@@ -533,16 +533,17 @@ static bool setupMPU() {
     if (getI2Cdata(MPUaddr, WHOAMI_REG, 1)) {
       // determine IMU model using whoami register
       byte iData = I2CDATA[0];
-      if (iData == MPU6050_ID) strcpy(mpuModel, "MPU6050");
-      if (iData == MPU6500_ID) strcpy(mpuModel, "MPU6520");
+      if (iData == MPU6050_ID) strncpy(mpuModel, "MPU6050", sizeof(mpuModel) - 1);
+      if (iData == MPU6500_ID) strncpy(mpuModel, "MPU6520", sizeof(mpuModel) - 1);
       if (iData == MPU9250_ID) {
-        strcpy(mpuModel, "MPU9250");
+        strncpy(mpuModel, "MPU9250", sizeof(mpuModel) - 1);
         haveMag = true;
       }
       if (iData == MPU9255_ID) {
-        strcpy(mpuModel, "MPU9255");
+        strncpy(mpuModel, "MPU9255", sizeof(mpuModel) - 1);
         haveMag = true;
       }
+      mpuModel[sizeof(mpuModel) - 1] = 0;
     }
     MPUok = haveMag ? setupMPU9250() : setupMPU6050();
     if (MPUok) LOG_INF("%s available", mpuModel);
@@ -555,8 +556,9 @@ float* getMPUdata() {
   return mpuData;
 }
 
-bool identifyMPU(char* _mpuModel) {
-  strcpy(_mpuModel, mpuModel);
+bool identifyMPU(char* _mpuModel, size_t maxLen) {
+  strncpy(_mpuModel, mpuModel, maxLen - 1);
+  _mpuModel[maxLen - 1] = 0;
   return haveMag;
 }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced unbounded `strcpy()` calls with safer bounded `strncpy()` calls when parsing the MPU model name in `periphsI2C.cpp`. In addition, updated the function signature of `identifyMPU()` in `periphsI2C.cpp` and `appGlobals.h` to accept a `size_t maxLen` parameter.

💡 **Why:** How this improves maintainability
Using `strncpy` followed by an explicit null termination provides compile-time intent of safety and prevents potential stack/buffer overflows compared to unbounded `strcpy`, improving both the codebase's overall security and code health.

✅ **Verification:** How you confirmed the change is safe
- Used `git diff --staged` to verify that all modifications were applied safely.
- Used a temporary mock test compilation to verify the string copying logic bounds appropriately.
- Confirmed via global searches (`grep -rnw "identifyMPU"`) that there are currently no un-updated external caller invocations breaking the compilation from the function signature change.

✨ **Result:** The improvement achieved
A safer and more robust module for identifying MPU properties without risks of string truncation overflows.

---
*PR created automatically by Jules for task [4880891576060768793](https://jules.google.com/task/4880891576060768793) started by @ManupaKDU*