### PR TITLE
🧹 Code Health: Replace sprintf with snprintf in utilsLog.cpp

### DIFF
--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -230,15 +230,15 @@ static void expandReason() {
   if (!btReason[0]) strcpy(btReason, "unknown");
 #if CONFIG_IDF_TARGET_ARCH_RISCV
   // riscV
-  else if (strstr(btReason, "Breakpoint") != NULL) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-  else if (strstr(btReason, "Stack protection fault") != NULL) sprintf(btReason, "stack overflow after HWM: %lu bytes", btHWM);  
+  else if (strstr(btReason, "Breakpoint") != NULL) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+  else if (strstr(btReason, "Stack protection fault") != NULL) snprintf(btReason, sizeof(btReason), "stack overflow after HWM: %lu bytes", btHWM);
   else if (!strcmp(btReason, "LoadAccessFault") || !strcmp(btReason, "StoreAccessFault") || !strcmp(btReason, "InstructionAccessFault")) strcat(btReason, " (pointer issue)");
 #else
   // Xtensa
   else if (strstr(btReason, "Unhandled debug exception") != NULL) {
-    if (btHWM < HWM_MIN) sprintf(btReason, "probably stack overflow @ HWM: %lu bytes", btHWM);
-    else if (btHWM > HWM_MAX) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-    else sprintf(btReason, "stack overflow / printf format. HWM: %lu bytes", btHWM); 
+    if (btHWM < HWM_MIN) snprintf(btReason, sizeof(btReason), "probably stack overflow @ HWM: %lu bytes", btHWM);
+    else if (btHWM > HWM_MAX) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+    else snprintf(btReason, sizeof(btReason), "stack overflow / printf format. HWM: %lu bytes", btHWM);
   }
   else if (!strcmp(btReason, "LoadProhibited") || !strcmp(btReason, "StoreProhibited") || !strcmp(btReason, "InstructionFetchError")) strcat(btReason, " (pointer issue)");
 #endif
@@ -368,7 +368,7 @@ static void boardInfo() {
 #endif
   char memInfo[100] = "none";
 #if !CONFIG_IDF_TARGET_ESP32C3
-  if (psramFound()) sprintf(memInfo, "%s, mode %s @ %dMhz", fmtSize(ESP.getPsramSize()), psramMode, CONFIG_SPIRAM_SPEED);
+  if (psramFound()) snprintf(memInfo, sizeof(memInfo), "%s, mode %s @ %dMhz", fmtSize(ESP.getPsramSize()), psramMode, CONFIG_SPIRAM_SPEED);
 #endif
   LOG_INF("PSRAM %s", memInfo);
 }
@@ -550,21 +550,35 @@ static void printGpioInfo() {
 
     char gpioInf[100];
     char* p = gpioInf;
+    int remaining = sizeof(gpioInf);
+    int written = 0;
 #if defined(BOARD_HAS_PIN_REMAP)
     int dpin = gpioNumberToDigitalPin(i);
     if (dpin < 0) continue;  //pin is not exported
-    else p+= sprintf(p, "  D%-3d|%4u : ", dpin, i);
+    else {
+      written = snprintf(p, remaining, "  D%-3d|%4u : ", dpin, i);
+      if (written > 0 && written < remaining) { p += written; remaining -= written; }
+    }
 #else
-    p+= sprintf(p, "  %4u : ", i);
+    written = snprintf(p, remaining, "  %4u : ", i);
+    if (written > 0 && written < remaining) { p += written; remaining -= written; }
 #endif
     const char *extra_type = perimanGetPinBusExtraType(i);
-    if (extra_type) p+= sprintf(p, "%s", extra_type);
-    else p+= sprintf(p, "%s", perimanGetTypeName(type));
+    if (extra_type) written = snprintf(p, remaining, "%s", extra_type);
+    else written = snprintf(p, remaining, "%s", perimanGetTypeName(type));
+    if (written > 0 && written < remaining) { p += written; remaining -= written; }
+
     int8_t bus_number = perimanGetPinBusNum(i);
-    if (bus_number != -1) p+= sprintf(p, "[%u]", bus_number);
+    if (bus_number != -1) {
+      written = snprintf(p, remaining, "[%u]", bus_number);
+      if (written > 0 && written < remaining) { p += written; remaining -= written; }
+    }
 
     int8_t bus_channel = perimanGetPinBusChannel(i);
-    if (bus_channel != -1) p+= sprintf(p, "[%u]", bus_channel);
+    if (bus_channel != -1) {
+      written = snprintf(p, remaining, "[%u]", bus_channel);
+      if (written > 0 && written < remaining) { p += written; remaining -= written; }
+    }
     *p = 0;
     LOG_SEND("%s\n", gpioInf);
   }


### PR DESCRIPTION
🎯 **What:** Replaced unsafe `sprintf` calls with `snprintf` in `utilsLog.cpp`.
💡 **Why:** Prevents potential buffer overflows, improving codebase maintainability and safety.
✅ **Verification:** Verified changes visually with git diff and ran local C++ tests (`test_utilsLog.cpp`).
✨ **Result:** A safer, more robust memory logging and hardware backtrace formatting implementation.

---
*PR created automatically by Jules for task [6592639991826074437](https://jules.google.com/task/6592639991826074437) started by @ManupaKDU*