### PR TITLE
🧹 Code Health: Replace sprintf with safer snprintf in utilsLog.cpp

### DIFF
--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -227,20 +227,20 @@ static void appPanicHandler(arduino_panic_info_t *info, void *arg) {
 }
 
 static void expandReason() {
-  if (!btReason[0]) strcpy(btReason, "unknown");
+  if (!btReason[0]) snprintf(btReason, sizeof(btReason), "unknown");
 #if CONFIG_IDF_TARGET_ARCH_RISCV
   // riscV
-  else if (strstr(btReason, "Breakpoint") != NULL) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-  else if (strstr(btReason, "Stack protection fault") != NULL) sprintf(btReason, "stack overflow after HWM: %lu bytes", btHWM);  
-  else if (!strcmp(btReason, "LoadAccessFault") || !strcmp(btReason, "StoreAccessFault") || !strcmp(btReason, "InstructionAccessFault")) strcat(btReason, " (pointer issue)");
+  else if (strstr(btReason, "Breakpoint") != NULL) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+  else if (strstr(btReason, "Stack protection fault") != NULL) snprintf(btReason, sizeof(btReason), "stack overflow after HWM: %lu bytes", btHWM);
+  else if (!strcmp(btReason, "LoadAccessFault") || !strcmp(btReason, "StoreAccessFault") || !strcmp(btReason, "InstructionAccessFault")) strncat(btReason, " (pointer issue)", sizeof(btReason) - strlen(btReason) - 1);
 #else
   // Xtensa
   else if (strstr(btReason, "Unhandled debug exception") != NULL) {
-    if (btHWM < HWM_MIN) sprintf(btReason, "probably stack overflow @ HWM: %lu bytes", btHWM);
-    else if (btHWM > HWM_MAX) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-    else sprintf(btReason, "stack overflow / printf format. HWM: %lu bytes", btHWM); 
+    if (btHWM < HWM_MIN) snprintf(btReason, sizeof(btReason), "probably stack overflow @ HWM: %lu bytes", btHWM);
+    else if (btHWM > HWM_MAX) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+    else snprintf(btReason, sizeof(btReason), "stack overflow / printf format. HWM: %lu bytes", btHWM);
   }
-  else if (!strcmp(btReason, "LoadProhibited") || !strcmp(btReason, "StoreProhibited") || !strcmp(btReason, "InstructionFetchError")) strcat(btReason, " (pointer issue)");
+  else if (!strcmp(btReason, "LoadProhibited") || !strcmp(btReason, "StoreProhibited") || !strcmp(btReason, "InstructionFetchError")) strncat(btReason, " (pointer issue)", sizeof(btReason) - strlen(btReason) - 1);
 #endif
 }
 


### PR DESCRIPTION
🎯 **What:** Replaced the unsafe `sprintf`, `strcpy`, and `strcat` functions with bounds-checked alternatives (`snprintf`, `strncpy`, `strncat`) in the `expandReason` function within `utilsLog.cpp`.

💡 **Why:** `sprintf`, `strcpy`, and `strcat` do not enforce buffer size limits, creating the potential for buffer overflow vulnerabilities if the written string length exceeds the size of the destination array. Replacing them with their length-bounded counterparts ensures memory safety and improves the overall maintainability and robustness of the panic handler logic.

✅ **Verification:** 
- Visual inspection was performed via `git diff` to ensure `snprintf` dynamically uses `sizeof(btReason)` to perfectly match the allocated buffer length.
- Successfully compiled and ran the local unit test for the file (`tests/test_utilsLog.cpp`), verifying no syntax errors or regressions were introduced. 

✨ **Result:** Enhanced the code health of the logging utility by comprehensively removing instances of unbounded string formatting, yielding identical logic but with strictly guaranteed bounds enforcement.

---
*PR created automatically by Jules for task [10990009174764113853](https://jules.google.com/task/10990009174764113853) started by @ManupaKDU*