### PR TITLE
🧹 [Code Health] Replace sprintf with snprintf in streamServer.cpp

### DIFF
--- a/streamServer.cpp
+++ b/streamServer.cpp
@@ -208,12 +208,16 @@ static void srtStream(httpd_req_t* req, uint8_t taskNum) {
     srtSeqNo++;
     uint32_t startTime = millis();
     formatElapsedTime(timeStr, srtTime, true);
-    size_t srtPtr = sprintf(srtHdr, "%d\n%s --> ", srtSeqNo, timeStr);
+    size_t srtPtr = snprintf(srtHdr, sizeof(srtHdr), "%d\n%s --> ", srtSeqNo, timeStr);
+    if (srtPtr >= sizeof(srtHdr)) srtPtr = sizeof(srtHdr) - 1;
     srtTime += sampleInterval;
     formatElapsedTime(timeStr, srtTime, true);
-    srtPtr += sprintf(srtHdr + srtPtr, "%s\n", timeStr);
+    int written = snprintf(srtHdr + srtPtr, sizeof(srtHdr) - srtPtr, "%s\n", timeStr);
+    if (written > 0 && written < sizeof(srtHdr) - srtPtr) srtPtr += written;
     time_t currEpoch = getEpoch();
-    srtPtr += strftime(srtHdr + srtPtr, 12, "%H:%M:%S  ", localtime(&currEpoch));
+    if (srtPtr < sizeof(srtHdr)) {
+      srtPtr += strftime(srtHdr + srtPtr, sizeof(srtHdr) - srtPtr, "%H:%M:%S  ", localtime(&currEpoch));
+    }
     httpd_resp_send_chunk(req, (const char*)srtHdr, srtPtr);
 #if INCLUDE_TELEM
     // add telemetry data 


### PR DESCRIPTION
🎯 **What:** Replaced `sprintf` calls with safer `snprintf` in `streamServer.cpp`.
💡 **Why:** Using `snprintf` with proper bounds checking ensures no buffer overflows occur if string inputs exceed the allocated buffer size.
✅ **Verification:** Verified that replacements were correctly applied, bounds checks work correctly and no regressions in local tests were introduced.
✨ **Result:** Improved maintainability and security against potential out-of-bounds writes.

---
*PR created automatically by Jules for task [16475409907148453012](https://jules.google.com/task/16475409907148453012) started by @ManupaKDU*