### PR TITLE
🛡️ Sentinel: High Fix buffer overflow in expandReason

### DIFF
--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -227,20 +227,26 @@ static void appPanicHandler(arduino_panic_info_t *info, void *arg) {
 }
 
 static void expandReason() {
-  if (!btReason[0]) strcpy(btReason, "unknown");
+  if (!btReason[0]) snprintf(btReason, sizeof(btReason), "unknown");
 #if CONFIG_IDF_TARGET_ARCH_RISCV
   // riscV
-  else if (strstr(btReason, "Breakpoint") != NULL) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-  else if (strstr(btReason, "Stack protection fault") != NULL) sprintf(btReason, "stack overflow after HWM: %lu bytes", btHWM);  
-  else if (!strcmp(btReason, "LoadAccessFault") || !strcmp(btReason, "StoreAccessFault") || !strcmp(btReason, "InstructionAccessFault")) strcat(btReason, " (pointer issue)");
+  else if (strstr(btReason, "Breakpoint") != NULL) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+  else if (strstr(btReason, "Stack protection fault") != NULL) snprintf(btReason, sizeof(btReason), "stack overflow after HWM: %lu bytes", btHWM);
+  else if (!strcmp(btReason, "LoadAccessFault") || !strcmp(btReason, "StoreAccessFault") || !strcmp(btReason, "InstructionAccessFault")) {
+    size_t len = strlen(btReason);
+    snprintf(btReason + len, sizeof(btReason) - len, " (pointer issue)");
+  }
 #else
   // Xtensa
   else if (strstr(btReason, "Unhandled debug exception") != NULL) {
-    if (btHWM < HWM_MIN) sprintf(btReason, "probably stack overflow @ HWM: %lu bytes", btHWM);
-    else if (btHWM > HWM_MAX) sprintf(btReason, "probably printf format"); // usually misplaced or misformatted vsnprintf()
-    else sprintf(btReason, "stack overflow / printf format. HWM: %lu bytes", btHWM); 
+    if (btHWM < HWM_MIN) snprintf(btReason, sizeof(btReason), "probably stack overflow @ HWM: %lu bytes", btHWM);
+    else if (btHWM > HWM_MAX) snprintf(btReason, sizeof(btReason), "probably printf format"); // usually misplaced or misformatted vsnprintf()
+    else snprintf(btReason, sizeof(btReason), "stack overflow / printf format. HWM: %lu bytes", btHWM);
   }
-  else if (!strcmp(btReason, "LoadProhibited") || !strcmp(btReason, "StoreProhibited") || !strcmp(btReason, "InstructionFetchError")) strcat(btReason, " (pointer issue)");
+  else if (!strcmp(btReason, "LoadProhibited") || !strcmp(btReason, "StoreProhibited") || !strcmp(btReason, "InstructionFetchError")) {
+    size_t len = strlen(btReason);
+    snprintf(btReason + len, sizeof(btReason) - len, " (pointer issue)");
+  }
 #endif
 }
 


### PR DESCRIPTION
🚨 Severity: High
💡 Vulnerability: Buffer overflow risk using `strcpy`, `strcat`, and `sprintf` without bounds checking in `expandReason` in `utilsLog.cpp`.
🎯 Impact: An attacker could potentially overflow `btReason` with a crafted stack trace reason and overwrite memory, leading to crashes or code execution.
🔧 Fix: Replaced `strcpy`, `strcat`, and `sprintf` with bounds-checked `snprintf` calls. Used `snprintf(btReason + len, sizeof(btReason) - len, ...)` for concatenations.
✅ Verification: Ran `g++ -o test_utilsLog tests/test_utilsLog.cpp && ./test_utilsLog` locally to ensure no compilation errors were introduced. Checked changes in the file for correct implementation.

---
*PR created automatically by Jules for task [15301221832855272346](https://jules.google.com/task/15301221832855272346) started by @ManupaKDU*