### PR TITLE
🧹 Code Health: Replace unsafe sprintf with snprintf in utilsLog.cpp

### DIFF
--- a/utilsLog.cpp
+++ b/utilsLog.cpp
@@ -550,22 +550,39 @@ static void printGpioInfo() {
 
     char gpioInf[100];
     char* p = gpioInf;
+    size_t len = 0;
+    int written = 0;
 #if defined(BOARD_HAS_PIN_REMAP)
     int dpin = gpioNumberToDigitalPin(i);
     if (dpin < 0) continue;  //pin is not exported
-    else p+= sprintf(p, "  D%-3d|%4u : ", dpin, i);
+    else {
+      written = snprintf(p + len, sizeof(gpioInf) - len, "  D%-3d|%4u : ", dpin, i);
+      if (written > 0) len += (written < sizeof(gpioInf) - len) ? written : sizeof(gpioInf) - len - 1;
+    }
 #else
-    p+= sprintf(p, "  %4u : ", i);
+    written = snprintf(p + len, sizeof(gpioInf) - len, "  %4u : ", i);
+    if (written > 0) len += (written < sizeof(gpioInf) - len) ? written : sizeof(gpioInf) - len - 1;
 #endif
     const char *extra_type = perimanGetPinBusExtraType(i);
-    if (extra_type) p+= sprintf(p, "%s", extra_type);
-    else p+= sprintf(p, "%s", perimanGetTypeName(type));
+    if (extra_type) {
+      written = snprintf(p + len, sizeof(gpioInf) - len, "%s", extra_type);
+      if (written > 0) len += (written < sizeof(gpioInf) - len) ? written : sizeof(gpioInf) - len - 1;
+    }
+    else {
+      written = snprintf(p + len, sizeof(gpioInf) - len, "%s", perimanGetTypeName(type));
+      if (written > 0) len += (written < sizeof(gpioInf) - len) ? written : sizeof(gpioInf) - len - 1;
+    }
     int8_t bus_number = perimanGetPinBusNum(i);
-    if (bus_number != -1) p+= sprintf(p, "[%u]", bus_number);
+    if (bus_number != -1) {
+      written = snprintf(p + len, sizeof(gpioInf) - len, "[%u]", bus_number);
+      if (written > 0) len += (written < sizeof(gpioInf) - len) ? written : sizeof(gpioInf) - len - 1;
+    }
 
     int8_t bus_channel = perimanGetPinBusChannel(i);
-    if (bus_channel != -1) p+= sprintf(p, "[%u]", bus_channel);
-    *p = 0;
+    if (bus_channel != -1) {
+      written = snprintf(p + len, sizeof(gpioInf) - len, "[%u]", bus_channel);
+      if (written > 0) len += (written < sizeof(gpioInf) - len) ? written : sizeof(gpioInf) - len - 1;
+    }
     LOG_SEND("%s\n", gpioInf);
   }
 }


### PR DESCRIPTION
🎯 **What:** Replaced unsafe `sprintf` chain with bounded `snprintf` in `printGpioInfo`, removing the redundant `*p = 0;` and properly handling string truncation to prevent buffer overflows.

💡 **Why:** Improves code safety and maintainability by ensuring string operations do not exceed the buffer bounds and behave correctly on truncation.

✅ **Verification:** Replaced `sprintf` with `snprintf`, fixed buffer length tracking on truncation, and removed buggy null-termination overwrite. Compiled the changes and ran the `test_utilsLog` test suite.

✨ **Result:** Safe, bounded string concatenations using `snprintf` with correct truncation handling.

---
*PR created automatically by Jules for task [5511874961918119864](https://jules.google.com/task/5511874961918119864) started by @ManupaKDU*