### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow in FTP post header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -197,3 +197,8 @@
 **Vulnerability:** A series of unsafe `sprintf` calls in `appSpecific.cpp` could result in buffer overflows, particularly when concatenating strings into a large JSON buffer via `p += sprintf(p, ...)`.
 **Learning:** Chained string concatenations using pointer manipulation (e.g. `p += sprintf(...)`) require careful attention to remain bounds-safe. A custom macro or inline check that tracks remaining space (`JSON_BUFF_LEN - (p - jsonBuff)`) and safely bounds the pointer increment using the return value of `snprintf` is required.
 **Prevention:** Always use `snprintf` when building dynamic strings in C++, particularly when writing sequentially into a fixed-length buffer using pointer arithmetic. Always bound the pointer increment to prevent overflow during truncation.
+
+## 2024-05-27 - Chaining snprintf pointer bounds in C/C++
+**Vulnerability:** Pointer advancement using `sprintf` without bounds checking in HTTP POST header generation (`p += sprintf(...)`) risks buffer overflows if content like file names, folder paths, or passwords exceeds expected lengths.
+**Learning:** When using a pointer to build a concatenated string in a bounded buffer, checking bounds at each step requires safely calculating the remaining buffer space (`CHUNKSIZE - (p - fsBuff)`) and using `snprintf`. Since `snprintf` returns the length it *would* have written upon truncation, you must cap the increment to prevent the pointer from escaping the buffer bounds (`p += (w < rem) ? w : rem - 1`).
+**Prevention:** Always replace unbounded `sprintf` chains with bounded `snprintf` macro calls that track and calculate remaining buffer length securely before pointer advancement.

--- a/ftp.cpp
+++ b/ftp.cpp
@@ -75,10 +75,15 @@ static void postHeader(const char* tmethod, const char* contentType, bool isFile
   // create http post header
   char* p = fsBuff + FORM_OFFSET; // leave space for http request data
   if (isFile) {
-    p += sprintf(p, FORM_DATA, "json", "", JSON_TYPE);
+    int w;
+    int rem = CHUNKSIZE - FORM_OFFSET;
+    w = snprintf(p, rem, FORM_DATA, "json", "", JSON_TYPE);
+    if (w > 0) { p += (w < rem) ? w : rem - 1; rem = CHUNKSIZE - (p - fsBuff); }
     // fsBuff initially contains folder name
-    p += sprintf(p, JSON_DATA, fsWd, folderPath, fileName, FS_Pass);
-    p += sprintf(p, "\r\n" FORM_DATA, FILE_NAME, fileName, BIN_TYPE); 
+    w = snprintf(p, rem, JSON_DATA, fsWd, folderPath, fileName, FS_Pass);
+    if (w > 0) { p += (w < rem) ? w : rem - 1; rem = CHUNKSIZE - (p - fsBuff); }
+    w = snprintf(p, rem, "\r\n" FORM_DATA, FILE_NAME, fileName, BIN_TYPE);
+    if (w > 0) { p += (w < rem) ? w : rem - 1; rem = CHUNKSIZE - (p - fsBuff); }
   } // else JSON data already loaded by hfsCreateFolder()
   size_t formLen = strlen(fsBuff + FORM_OFFSET);
   // create http request header


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unbounded pointer-advancement using `sprintf` (`p += sprintf(...)`) inside `postHeader` in `ftp.cpp`.
🎯 Impact: If filename, path, or password lengths exceed expected bounds, `sprintf` could overflow the `fsBuff` allocation, leading to heap corruption, crashes, or potential code execution vulnerabilities.
🔧 Fix: Replaced `p += sprintf(...)` with explicitly bounded `snprintf` calls, calculating the remaining space in the `fsBuff` buffer (size `CHUNKSIZE`) at each step.
✅ Verification: Manual code review confirms pointer bounds are properly managed and memory corruption is prevented.

---
*PR created automatically by Jules for task [16627176349356230886](https://jules.google.com/task/16627176349356230886) started by @ManupaKDU*